### PR TITLE
ci: 릴리스 워크플로우에 GITHUB_TOKEN 환경 변수 추가

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,8 @@ jobs:
       # 사전에 생성된 Changeset 정보를 이용하여 버저닝을 수행한다.
       - name: Create Semantic Versioning
         run: yarn changeset version
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # 각 라이브러리의 배포를 수행한다.
       - name: Create Release Pull Request or Publish to npm


### PR DESCRIPTION
## 개요

- Github Actions를 통해 release가 수행되지 않는 문제를 수정합니다.

## 작업 내용

- release workflow 중 versioning 과정에서, Github Token의 부재로 실행되지 못했던 문제를 수정했습니다.

## 참고