### PR TITLE
Fix: Wrong Turborepo Task Deps

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -2,13 +2,13 @@
   "$schema": "https://turborepo.com/schema.json",
   "ui": "tui",
   "tasks": {
-    "test": {
-      "dependsOn": ["^test"]
-    },
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "test", "check-types", "lint", "format"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": [".next/**", "!.next/cache/**", "dist"]
+    },
+    "test": {
+      "dependsOn": ["^test"]
     },
     "lint": {
       "dependsOn": ["^lint"]
@@ -18,9 +18,6 @@
     },
     "check-types": {
       "dependsOn": ["^check-types"]
-    },
-    "release": {
-      "dependsOn": ["lint", "format", "build", "test"]
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
## 개요

- Turborepo로 배포하는 과정에서 Lint 및 Test가 수행되지 않는 문제를 해결합니다.

## 작업 내용

- turbo.json에서 release 명령어에 지정된 의존성을 제거하고, build 명령어에 지정하였습니다.
