### PR TITLE
feat(next-loader-tag): 초기 버전 구성

### DIFF
--- a/.changeset/slimy-zoos-ask.md
+++ b/.changeset/slimy-zoos-ask.md
@@ -1,0 +1,5 @@
+---
+"@h1y/next-loader-tag": major
+---
+
+initial release

--- a/packages/tag/README.md
+++ b/packages/tag/README.md
@@ -1,0 +1,210 @@
+# @h1y/next-loader-tag
+
+타입 안전한 태그 시스템을 제공하는 TypeScript 라이브러리입니다. 정적 태그와 동적 태그를 지원하며, 이들을 조합하여 복합 태그나 계층적 태그를 만들 수 있습니다.
+
+## 설치
+
+```bash
+npm install @h1y/next-loader-tag
+```
+
+또는
+
+```bash
+yarn add @h1y/next-loader-tag
+```
+
+## 주요 기능
+
+- **정적 태그**: 고정된 문자열 태그
+- **동적 태그**: 매개변수를 받아 동적으로 생성되는 태그
+- **복합 태그 (Composite)**: 여러 태그를 `_`로 조합
+- **계층적 태그 (Hierarchy)**: 여러 태그를 `/`로 계층 구조화
+- **완전한 TypeScript 지원**: 타입 안전성과 자동완성 제공
+
+## 사용법
+
+### 기본 태그 생성
+
+```typescript
+import { tag } from '@h1y/next-loader-tag';
+
+// 정적 태그
+const userTag = tag("user");
+console.log(userTag.result); // "user"
+
+// 동적 태그
+const dynamicUserTag = tag((id: number) => tag(`user-${id}`));
+const resolved = dynamicUserTag.resolver(123);
+console.log(resolved.result); // "user-123"
+```
+
+### 복합 태그 (Composite Tags)
+
+여러 태그를 `_`로 조합하여 하나의 태그를 만듭니다.
+
+```typescript
+import { tag, compose } from '@h1y/next-loader-tag';
+
+// 정적 태그들 조합
+const appTag = tag("myapp");
+const userTag = tag("user");
+const actionTag = tag("login");
+
+const compositeTag = compose(appTag, userTag, actionTag);
+const resolved = compositeTag.resolver();
+console.log(resolved.result); // "myapp_user_login"
+
+// 동적 태그들 조합
+const dynamicUserTag = tag((id: number) => tag(`user-${id}`));
+const dynamicActionTag = tag((action: string) => tag(`action-${action}`));
+
+const dynamicComposite = compose(appTag, dynamicUserTag, dynamicActionTag);
+const dynamicResolved = dynamicComposite.resolver([123], ["click"]);
+console.log(dynamicResolved.result); // "myapp_user-123_action-click"
+```
+
+### 계층적 태그 (Hierarchy Tags)
+
+여러 태그를 `/`로 연결하여 계층 구조를 만듭니다. 각 단계별 경로를 배열로 반환합니다.
+
+```typescript
+import { tag, hierarchy } from '@h1y/next-loader-tag';
+
+// 파일 시스템 경로 구조
+const rootTag = tag("home");
+const userTag = tag((username: string) => tag(username));
+const folderTag = tag("documents");
+const fileTag = tag((filename: string) => tag(filename));
+
+const pathTag = hierarchy(rootTag, userTag, folderTag, fileTag);
+const resolved = pathTag.resolver(["john"], ["report.pdf"]);
+
+console.log(resolved.result);
+// [
+//   "home",
+//   "home/john",
+//   "home/john/documents",
+//   "home/john/documents/report.pdf"
+// ]
+```
+
+## 실제 사용 예시
+
+### 사용자 액션 추적
+
+```typescript
+import { tag, compose } from '@h1y/next-loader-tag';
+
+const appTag = tag("analytics");
+const userTag = tag((userId: number) => tag(`user-${userId}`));
+const actionTag = tag((action: string) => tag(`action-${action}`));
+
+const trackingTag = compose(appTag, userTag, actionTag);
+const eventTag = trackingTag.resolver([123], ["button-click"]);
+
+console.log(eventTag.result); // "analytics_user-123_action-button-click"
+```
+
+### API 엔드포인트 경로 생성
+
+```typescript
+import { tag, hierarchy } from '@h1y/next-loader-tag';
+
+const domainTag = tag("api.example.com");
+const versionTag = tag("v1");
+const resourceTag = tag((resource: string) => tag(resource));
+const idTag = tag((id: number) => tag(id.toString()));
+
+const apiPathTag = hierarchy(domainTag, versionTag, resourceTag, idTag);
+const paths = apiPathTag.resolver(["users"], [123]);
+
+console.log(paths.result);
+// [
+//   "api.example.com",
+//   "api.example.com/v1", 
+//   "api.example.com/v1/users",
+//   "api.example.com/v1/users/123"
+// ]
+```
+
+### 조직 리소스 네임스페이스
+
+```typescript
+import { tag, compose } from '@h1y/next-loader-tag';
+
+const orgTag = tag("acme-corp");
+const deptTag = tag((dept: string) => tag(`dept:${dept}`));
+const projectTag = tag((project: string) => tag(`project:${project}`));
+const resourceTag = tag("resource");
+
+const resourcePathTag = compose(orgTag, deptTag, projectTag, resourceTag);
+const resourceId = resourcePathTag.resolver(["engineering"], ["web-app"]);
+
+console.log(resourceId.result); // "acme-corp_dept:engineering_project:web-app_resource"
+```
+
+## API 참조
+
+### `tag(value)`
+
+기본 태그를 생성합니다.
+
+**매개변수:**
+
+- `value: string | Function` - 정적 태그의 경우 문자열, 동적 태그의 경우 resolver 함수
+
+**반환값:**
+
+- `SingleTag` - 생성된 태그 객체
+
+### `compose(...tags)`
+
+여러 태그를 `_`로 조합하여 복합 태그를 생성합니다.
+
+**매개변수:**
+
+- `...tags: SingleTag[]` - 조합할 태그들
+
+**반환값:**
+
+- `CompositeTag` - 조합된 태그 객체
+
+### `hierarchy(...tags)`
+
+여러 태그를 `/`로 연결하여 계층적 태그를 생성합니다.
+
+**매개변수:**
+
+- `...tags: SingleTag[]` - 계층을 구성할 태그들
+
+**반환값:**
+
+- `HierarchyTag` - 계층적 태그 객체
+
+## 타입 시스템
+
+이 라이브러리는 완전한 TypeScript 지원을 제공하며, 컴파일 타임에 타입 안전성을 보장합니다.
+
+```typescript
+// 타입 추론 예시
+const userTag = tag((id: number) => tag(`user-${id}`));
+const actionTag = tag((action: string) => tag(`action-${action}`));
+
+const composite = compose(userTag, actionTag);
+// TypeScript가 매개변수 타입을 자동으로 추론합니다
+const resolved = composite.resolver([123], ["click"]); // ✅ 올바른 타입
+// const resolved = composite.resolver(["123"], [123]); // ❌ 타입 에러
+```
+
+## 라이선스
+
+MIT
+
+## 기여하기
+
+이슈나 풀 리퀘스트를 통해 기여해 주세요.
+
+## 개발자
+
+h1ylabs 

--- a/packages/tag/eslint.config.mjs
+++ b/packages/tag/eslint.config.mjs
@@ -1,0 +1,3 @@
+import config from "@h1y/next-loader-eslint-config/base";
+
+export default config;

--- a/packages/tag/jest.config.mjs
+++ b/packages/tag/jest.config.mjs
@@ -1,0 +1,14 @@
+/** @type {import('jest').Config} */
+export default {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  extensionsToTreatAsEsm: [".ts"],
+  transform: {
+    "^.+\\.ts$": [
+      "ts-jest",
+      {
+        useESM: true,
+      },
+    ],
+  },
+};

--- a/packages/tag/package.json
+++ b/packages/tag/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@h1y/next-loader-tag",
+  "version": "0.0.0",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "author": "h1ylabs",
+  "keywords": [],
+  "type": "module",
+  "sideEffects": false,
+  "files": [
+    "dist",
+    "README.md",
+    "package.json"
+  ],
+  "exports": {
+    ".": {
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      },
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "dev": "tsup --watch",
+    "build": "yarn clean && tsup",
+    "format": "prettier --cache --write \"./src/**/*.{ts,tsx}\"",
+    "format:file": "prettier --cache --write",
+    "check-types": "bash -c \"tsc --skipLibCheck --noEmit\"",
+    "clean": "rimraf ./dist",
+    "lint": "eslint --cache --max-warnings=0",
+    "test": "jest --coverage"
+  },
+  "devDependencies": {
+    "@h1y/next-loader-eslint-config": "*",
+    "@h1y/next-loader-typescript-config": "*",
+    "@types/jest": "^29.5.14",
+    "@types/node": "^22.15.29",
+    "jest": "^30.0.0",
+    "ts-jest": "^29.4.0",
+    "tsup": "^8.5.0",
+    "typescript": "^5.8.3"
+  }
+}

--- a/packages/tag/src/__tests__/composite.test.ts
+++ b/packages/tag/src/__tests__/composite.test.ts
@@ -1,0 +1,148 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { compose } from "../compose";
+import { tag } from "../tag";
+
+describe("composite 함수", () => {
+  describe("기본 기능", () => {
+    it("정적 태그들을 조합할 수 있다", () => {
+      const tag1 = tag("user");
+      const tag2 = tag("profile");
+      const tag3 = tag("view");
+
+      const compositeTag = compose(tag1, tag2, tag3);
+
+      expect(compositeTag.type).toBe("composite");
+      expect(compositeTag.resolved).toBe(false);
+      expect(typeof compositeTag.resolver).toBe("function");
+    });
+
+    it("정적 태그들을 조합하여 해결할 수 있다", () => {
+      const tag1 = tag("user");
+      const tag2 = tag("profile");
+
+      const compositeTag = compose(tag1, tag2);
+      const resolved = compositeTag.resolver();
+
+      expect(resolved.type).toBe("composite");
+      expect(resolved.resolved).toBe(true);
+      expect(resolved.result).toBe("user_profile");
+    });
+
+    it("동적 태그들을 조합할 수 있다", () => {
+      const userTag = tag((id: number) => tag(`user-${id}`));
+      const actionTag = tag(<T extends string>(action: T) =>
+        tag(`action-${action}`),
+      );
+
+      const compositeTag = compose(userTag, actionTag);
+      const resolved = compositeTag.resolver([123], ["click"]);
+
+      expect(resolved.result).toBe("user-123_action-click");
+    });
+
+    it("정적 태그와 동적 태그를 혼합하여 조합할 수 있다", () => {
+      const staticTag = tag("app");
+      const dynamicTag = tag((id: number) => tag(`user-${id}`));
+      const staticTag2 = tag("dashboard");
+
+      const compositeTag = compose(staticTag, dynamicTag, staticTag2);
+      const resolved = compositeTag.resolver([456]);
+
+      expect(resolved.result).toBe("app_user-456_dashboard");
+    });
+  });
+
+  describe("복잡한 시나리오", () => {
+    it("여러 매개변수를 받는 동적 태그들을 조합할 수 있다", () => {
+      const userTag = tag(<T extends string>(namespace: T, id: number) =>
+        tag(`${namespace}-${id}`),
+      );
+      const actionTag = tag(<T extends string>(action: T, timestamp: number) =>
+        tag(`${action}-${timestamp}`),
+      );
+
+      const compositeTag = compose(userTag, actionTag);
+      const resolved = compositeTag.resolver(
+        ["app", 123],
+        ["click", 1234567890],
+      );
+
+      expect(resolved.result).toBe("app-123_click-1234567890");
+    });
+
+    it("단일 태그도 조합할 수 있다", () => {
+      const singleTag = tag("standalone");
+
+      const compositeTag = compose(singleTag);
+      const resolved = compositeTag.resolver();
+
+      expect(resolved.result).toBe("standalone");
+    });
+
+    it("Generic을 활용한 정확한 타입 추론 테스트", () => {
+      const roleTag = tag(<T extends string>(role: T) => tag(`role:${role}`));
+      const actionTag = tag(<T extends string>(action: T) =>
+        tag(`action:${action}`),
+      );
+
+      const compositeTag = compose(roleTag, actionTag);
+      const resolved = compositeTag.resolver(["admin"], ["login"]);
+
+      expect(resolved.result).toBe("role:admin_action:login");
+    });
+  });
+
+  describe("에러 처리", () => {
+    it("빈 태그 배열로 조합을 시도하면 에러가 발생한다", () => {
+      expect(() => {
+        (compose as any)();
+      }).toThrow("Error: at least a single tag required.");
+    });
+
+    it("동적 태그의 resolver가 실행 중 에러를 발생시키면 전파된다", () => {
+      const errorTag = tag((shouldError: boolean) => {
+        if (shouldError) {
+          throw new Error("Dynamic tag error");
+        }
+        return tag("success");
+      });
+
+      const compositeTag = compose(errorTag);
+
+      // 에러가 발생하는 경우
+      expect(() => compositeTag.resolver([true])).toThrow("Dynamic tag error");
+
+      // 정상 동작하는 경우
+      const resolved = compositeTag.resolver([false]);
+      expect(resolved.result).toBe("success");
+    });
+  });
+
+  describe("실제 사용 시나리오", () => {
+    it("사용자 액션 추적 태그를 구성할 수 있다", () => {
+      const appTag = tag("myapp");
+      const userTag = tag((userId: number) => tag(`user-${userId}`));
+      const actionTag = tag(<T extends string>(action: T) =>
+        tag(`action-${action}`),
+      );
+
+      const trackingTag = compose(appTag, userTag, actionTag);
+      const resolved = trackingTag.resolver([123], ["button-click"]);
+
+      expect(resolved.result).toBe("myapp_user-123_action-button-click");
+    });
+
+    it("계층적 네임스페이스 태그 구성", () => {
+      const orgTag = tag(<T extends string>(orgId: T) => tag(`org:${orgId}`));
+      const projectTag = tag(<T extends string>(projectId: T) =>
+        tag(`project:${projectId}`),
+      );
+      const resourceTag = tag("resource");
+
+      const resourcePathTag = compose(orgTag, projectTag, resourceTag);
+      const resolved = resourcePathTag.resolver(["acme"], ["web-app"]);
+
+      expect(resolved.result).toBe("org:acme_project:web-app_resource");
+    });
+  });
+});

--- a/packages/tag/src/__tests__/hierarchy.test.ts
+++ b/packages/tag/src/__tests__/hierarchy.test.ts
@@ -1,0 +1,267 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { hierarchy } from "../hierarchy";
+import { tag } from "../tag";
+
+describe("hierarchy 함수", () => {
+  describe("기본 기능", () => {
+    it("정적 태그들을 계층적으로 조합할 수 있다", () => {
+      const tag1 = tag("category");
+      const tag2 = tag("subcategory");
+      const tag3 = tag("item");
+
+      const hierarchyTag = hierarchy(tag1, tag2, tag3);
+
+      expect(hierarchyTag.type).toBe("hierarchy");
+      expect(hierarchyTag.resolved).toBe(false);
+      expect(typeof hierarchyTag.resolver).toBe("function");
+    });
+
+    it("정적 태그들을 계층적으로 조합하여 해결할 수 있다", () => {
+      const tag1 = tag("category");
+      const tag2 = tag("subcategory");
+      const tag3 = tag("item");
+
+      const hierarchyTag = hierarchy(tag1, tag2, tag3);
+      const resolved = hierarchyTag.resolver();
+
+      expect(resolved.type).toBe("hierarchy");
+      expect(resolved.resolved).toBe(true);
+      expect(resolved.result).toEqual([
+        "category",
+        "category/subcategory",
+        "category/subcategory/item",
+      ]);
+    });
+
+    it("동적 태그들을 계층적으로 조합할 수 있다", () => {
+      const categoryTag = tag((category: string) => tag(`cat-${category}`));
+      const itemTag = tag((item: string) => tag(`item-${item}`));
+
+      const hierarchyTag = hierarchy(categoryTag, itemTag);
+      const resolved = hierarchyTag.resolver(["electronics"], ["laptop"]);
+
+      expect(resolved.result).toEqual([
+        "cat-electronics",
+        "cat-electronics/item-laptop",
+      ]);
+    });
+
+    it("정적 태그와 동적 태그를 혼합하여 계층 구성할 수 있다", () => {
+      const rootTag = tag("store");
+      const categoryTag = tag((category: string) => tag(category));
+      const itemTag = tag("product");
+
+      const hierarchyTag = hierarchy(rootTag, categoryTag, itemTag);
+      const resolved = hierarchyTag.resolver(["books"]);
+
+      expect(resolved.result).toEqual([
+        "store",
+        "store/books",
+        "store/books/product",
+      ]);
+    });
+  });
+
+  describe("복잡한 시나리오", () => {
+    it("여러 매개변수를 받는 동적 태그들을 계층 구성할 수 있다", () => {
+      const orgTag = tag((org: string, region: string) =>
+        tag(`${org}-${region}`),
+      );
+      const deptTag = tag((dept: string, team: string) =>
+        tag(`${dept}-${team}`),
+      );
+      const resourceTag = tag("resource");
+
+      const hierarchyTag = hierarchy(orgTag, deptTag, resourceTag);
+      const resolved = hierarchyTag.resolver(
+        ["acme", "us"],
+        ["engineering", "backend"],
+      );
+
+      expect(resolved.result).toEqual([
+        "acme-us",
+        "acme-us/engineering-backend",
+        "acme-us/engineering-backend/resource",
+      ]);
+    });
+
+    it("단일 태그도 계층 구조로 처리할 수 있다", () => {
+      const singleTag = tag("root");
+
+      const hierarchyTag = hierarchy(singleTag);
+      const resolved = hierarchyTag.resolver();
+
+      expect(resolved.result).toEqual(["root"]);
+    });
+
+    it("두 개의 태그로 계층 구조를 만들 수 있다", () => {
+      const parentTag = tag("parent");
+      const childTag = tag((child: string) => tag(child));
+
+      const hierarchyTag = hierarchy(parentTag, childTag);
+      const resolved = hierarchyTag.resolver(["child"]);
+
+      expect(resolved.result).toEqual(["parent", "parent/child"]);
+    });
+
+    it("Generic을 활용한 정확한 타입 추론 테스트", () => {
+      const namespaceTag = tag((ns: string) => tag(`ns:${ns}`));
+      const serviceTag = tag((service: string) => tag(`service:${service}`));
+      const versionTag = tag((version: string) => tag(`v${version}`));
+
+      const hierarchyTag = hierarchy(namespaceTag, serviceTag, versionTag);
+      const resolved = hierarchyTag.resolver(
+        ["production"],
+        ["api"],
+        ["2.1.0"],
+      );
+
+      expect(resolved.result).toEqual([
+        "ns:production",
+        "ns:production/service:api",
+        "ns:production/service:api/v2.1.0",
+      ]);
+    });
+  });
+
+  describe("에러 처리", () => {
+    it("빈 태그 배열로 계층 구성을 시도하면 에러가 발생한다", () => {
+      expect(() => {
+        (hierarchy as any)();
+      }).toThrow("Error: at least a single tag required.");
+    });
+
+    it("동적 태그의 resolver가 실행 중 에러를 발생시키면 전파된다", () => {
+      const errorTag = tag((shouldError: boolean) => {
+        if (shouldError) {
+          throw new Error("Dynamic tag error");
+        }
+        return tag("success");
+      });
+
+      const hierarchyTag = hierarchy(errorTag);
+
+      // 에러가 발생하는 경우
+      expect(() => hierarchyTag.resolver([true])).toThrow("Dynamic tag error");
+
+      // 정상 동작하는 경우
+      const resolved = hierarchyTag.resolver([false]);
+      expect(resolved.result).toEqual(["success"]);
+    });
+
+    it("잘못된 태그가 포함된 경우 에러를 발생시킨다", () => {
+      const validTag = tag("valid");
+      const invalidTag = { type: "single", resolved: false } as any; // resolver 없음
+
+      const hierarchyTag = hierarchy(validTag, invalidTag);
+
+      expect(() => hierarchyTag.resolver()).toThrow("Invalid tag at index 1");
+    });
+  });
+
+  describe("실제 사용 시나리오", () => {
+    it("파일 시스템 경로 구조를 생성할 수 있다", () => {
+      const rootTag = tag("home");
+      const userTag = tag((username: string) => tag(username));
+      const folderTag = tag("documents");
+      const fileTag = tag((filename: string) => tag(filename));
+
+      const pathTag = hierarchy(rootTag, userTag, folderTag, fileTag);
+      const resolved = pathTag.resolver(["john"], ["report.pdf"]);
+
+      expect(resolved.result).toEqual([
+        "home",
+        "home/john",
+        "home/john/documents",
+        "home/john/documents/report.pdf",
+      ]);
+    });
+
+    it("URL 경로 구조를 생성할 수 있다", () => {
+      const domainTag = tag("api.example.com");
+      const versionTag = tag("v1");
+      const resourceTag = tag((resource: string) => tag(resource));
+      const idTag = tag((id: number) => tag(id.toString()));
+
+      const urlTag = hierarchy(domainTag, versionTag, resourceTag, idTag);
+      const resolved = urlTag.resolver(["users"], [123]);
+
+      expect(resolved.result).toEqual([
+        "api.example.com",
+        "api.example.com/v1",
+        "api.example.com/v1/users",
+        "api.example.com/v1/users/123",
+      ]);
+    });
+
+    it("네임스페이스 기반 리소스 경로 구성", () => {
+      const clusterTag = tag((cluster: string) => tag(cluster));
+      const namespaceTag = tag((namespace: string) => tag(namespace));
+      const typeTag = tag("deployment");
+      const nameTag = tag((name: string) => tag(name));
+
+      const resourcePathTag = hierarchy(
+        clusterTag,
+        namespaceTag,
+        typeTag,
+        nameTag,
+      );
+      const resolved = resourcePathTag.resolver(
+        ["prod-cluster"],
+        ["backend"],
+        ["api-server"],
+      );
+
+      expect(resolved.result).toEqual([
+        "prod-cluster",
+        "prod-cluster/backend",
+        "prod-cluster/backend/deployment",
+        "prod-cluster/backend/deployment/api-server",
+      ]);
+    });
+
+    it("조직 구조 계층을 생성할 수 있다", () => {
+      const companyTag = tag("company");
+      const divisionTag = tag((division: string) => tag(division));
+      const departmentTag = tag((dept: string) => tag(dept));
+      const teamTag = tag((team: string) => tag(team));
+
+      const orgTag = hierarchy(companyTag, divisionTag, departmentTag, teamTag);
+      const resolved = orgTag.resolver(
+        ["engineering"],
+        ["backend"],
+        ["api-team"],
+      );
+
+      expect(resolved.result).toEqual([
+        "company",
+        "company/engineering",
+        "company/engineering/backend",
+        "company/engineering/backend/api-team",
+      ]);
+    });
+  });
+
+  describe("엣지 케이스", () => {
+    it("빈 문자열 태그도 계층에 포함할 수 있다", () => {
+      const rootTag = tag("");
+      const childTag = tag("child");
+
+      const hierarchyTag = hierarchy(rootTag, childTag);
+      const resolved = hierarchyTag.resolver();
+
+      expect(resolved.result).toEqual(["", "child"]);
+    });
+
+    it("동일한 값을 가진 태그들을 계층 구성할 수 있다", () => {
+      const tag1 = tag("same");
+      const tag2 = tag("same");
+      const tag3 = tag("same");
+
+      const hierarchyTag = hierarchy(tag1, tag2, tag3);
+      const resolved = hierarchyTag.resolver();
+
+      expect(resolved.result).toEqual(["same", "same/same", "same/same/same"]);
+    });
+  });
+});

--- a/packages/tag/src/__tests__/tag.test.ts
+++ b/packages/tag/src/__tests__/tag.test.ts
@@ -1,0 +1,55 @@
+import { tag } from "../tag";
+
+describe("tag 함수", () => {
+  describe("정적 태그 생성", () => {
+    it("문자열로 정적 태그를 생성할 수 있다", () => {
+      const staticTag = tag("user");
+
+      expect(staticTag.type).toBe("single");
+      expect(staticTag.resolved).toBe(true);
+      expect(staticTag.result).toBe("user");
+    });
+
+    it("빈 문자열로도 정적 태그를 생성할 수 있다", () => {
+      const emptyTag = tag("");
+
+      expect(emptyTag.type).toBe("single");
+      expect(emptyTag.resolved).toBe(true);
+      expect(emptyTag.result).toBe("");
+    });
+  });
+
+  describe("동적 태그 생성", () => {
+    it("resolver 함수로 동적 태그를 생성할 수 있다", () => {
+      const dynamicTag = tag((id: number) => tag(`user-${id}`));
+
+      expect(dynamicTag.type).toBe("single");
+      expect(dynamicTag.resolved).toBe(false);
+      expect(typeof dynamicTag.resolver).toBe("function");
+    });
+
+    it("여러 매개변수를 받는 resolver로 동적 태그를 생성할 수 있다", () => {
+      const dynamicTag = tag(
+        <T extends string, U extends string, V extends number>(
+          namespace: T,
+          id: V,
+          action: U,
+        ) => tag(`${namespace}-${id}-${action}`),
+      );
+      const resolved = dynamicTag.resolver("app", 123, "click");
+
+      expect(resolved.result).toBe("app-123-click");
+    });
+  });
+
+  describe("에러 처리", () => {
+    it("유효하지 않은 입력에 대해 에러를 발생시킨다", () => {
+      expect(() => {
+        // @ts-expect-error - 의도적으로 잘못된 타입 전달
+        tag(123);
+      }).toThrow(
+        "Unexpected error: resolver is valid but doesn't match any known type.",
+      );
+    });
+  });
+});

--- a/packages/tag/src/compose.ts
+++ b/packages/tag/src/compose.ts
@@ -1,0 +1,44 @@
+import {
+  CompositeTagParameters,
+  CompositeTagResolver,
+  CompositeTagResult,
+  SingleTag,
+  UnresolvedCompositeTag,
+} from "./types";
+
+export function compose<
+  Tags extends readonly SingleTag[],
+  Params extends CompositeTagParameters<Tags> = CompositeTagParameters<Tags>,
+  Result extends CompositeTagResult<Tags> = CompositeTagResult<Tags>,
+  Resolver extends CompositeTagResolver<
+    Tags,
+    Params,
+    Result
+  > = CompositeTagResolver<Tags, Params, Result>,
+>(...tags: Tags): UnresolvedCompositeTag<Tags, Params, Result, Resolver> {
+  if (tags.length === 0) {
+    throw new Error("Error: at least a single tag required.");
+  }
+
+  const resolver = ((...args: Params) => {
+    let argIndex = 0;
+    const results = tags.map((tag) =>
+      tag.resolved
+        ? tag.result
+        : tag.resolver(...(args[argIndex++] as Parameters<typeof tag.resolver>))
+            .result,
+    );
+
+    return {
+      type: "composite" as const,
+      resolved: true as const,
+      result: results.join("_") as Result,
+    };
+  }) as Resolver;
+
+  return {
+    type: "composite",
+    resolved: false,
+    resolver,
+  };
+}

--- a/packages/tag/src/hierarchy.ts
+++ b/packages/tag/src/hierarchy.ts
@@ -1,0 +1,56 @@
+import {
+  HierarchyTagParameters,
+  HierarchyTagResolver,
+  HierarchyTagResult,
+  SingleTag,
+  UnresolvedHierarchyTag,
+} from "./types";
+
+export function hierarchy<
+  Tags extends readonly SingleTag[],
+  Params extends HierarchyTagParameters<Tags> = HierarchyTagParameters<Tags>,
+  Result extends HierarchyTagResult<Tags> = HierarchyTagResult<Tags>,
+  Resolver extends HierarchyTagResolver<
+    Tags,
+    Params,
+    Result
+  > = HierarchyTagResolver<Tags, Params, Result>,
+>(...tags: Tags): UnresolvedHierarchyTag<Tags, Params, Result, Resolver> {
+  if (tags.length === 0) {
+    throw new Error("Error: at least a single tag required.");
+  }
+
+  const resolver = ((...args: Params) => {
+    let argIndex = 0;
+    let path = "";
+    const results: string[] = [];
+
+    for (const tag of tags) {
+      const tagResult =
+        tag.resolved && "result" in tag
+          ? tag.result
+          : !tag.resolved && "resolver" in tag
+            ? tag.resolver(
+                ...(args[argIndex++] as Parameters<typeof tag.resolver>),
+              ).result
+            : (() => {
+                throw new Error(`Invalid tag at index ${results.length}`);
+              })();
+
+      path = path ? `${path}/${tagResult}` : tagResult;
+      results.push(path);
+    }
+
+    return {
+      type: "hierarchy" as const,
+      resolved: true as const,
+      result: results as Result,
+    };
+  }) as Resolver;
+
+  return {
+    type: "hierarchy",
+    resolved: false,
+    resolver,
+  };
+}

--- a/packages/tag/src/index.ts
+++ b/packages/tag/src/index.ts
@@ -1,0 +1,3 @@
+export { compose } from "./compose";
+export { hierarchy } from "./hierarchy";
+export { tag } from "./tag";

--- a/packages/tag/src/tag.ts
+++ b/packages/tag/src/tag.ts
@@ -1,0 +1,44 @@
+import {
+  ResolvedSingleTag,
+  SingleTag,
+  SingleTagParameters,
+  SingleTagResult,
+  SingleTypeResolver,
+  UnresolvedSingleTag,
+} from "./types";
+
+export function tag<
+  Params extends SingleTagParameters,
+  Result extends SingleTagResult,
+  Resolver extends SingleTypeResolver<Params, Result>,
+>(resolver: Resolver): UnresolvedSingleTag<Params, Result, Resolver>;
+
+export function tag<Result extends SingleTagResult>(
+  tag: Result,
+): ResolvedSingleTag<Result>;
+
+export function tag<
+  Params extends SingleTagParameters,
+  Result extends SingleTagResult,
+  Resolver extends SingleTypeResolver<Params, Result>,
+>(value: Resolver | Result): SingleTag<Params, Result, Resolver> {
+  if (typeof value === "string") {
+    return {
+      type: "single",
+      resolved: true,
+      result: value,
+    };
+  }
+
+  if (typeof value === "function") {
+    return {
+      type: "single",
+      resolved: false,
+      resolver: value,
+    };
+  }
+
+  throw new Error(
+    "Unexpected error: resolver is valid but doesn't match any known type.",
+  );
+}

--- a/packages/tag/src/types.ts
+++ b/packages/tag/src/types.ts
@@ -1,0 +1,213 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// Common Tag Types
+type UnresolvedTag = {
+  readonly resolved: false;
+};
+
+type ResolvedTag<T extends string = string> = {
+  readonly resolved: true;
+  readonly result: T;
+};
+
+type ResolvedMultipleTag<T extends string[] = string[]> = {
+  readonly resolved: true;
+  readonly result: T;
+};
+
+type TagType = "single" | "composite" | "hierarchy";
+type Tag<Type extends TagType> = { type: Type };
+
+type Merge<
+  T extends string,
+  U extends string,
+  Connection extends string,
+> = T extends "" ? U : `${T}${Connection}${U}`;
+
+// Single Tag
+export type SingleTag<
+  Params extends SingleTagParameters = SingleTagParameters,
+  Result extends SingleTagResult = SingleTagResult,
+  Resolver extends SingleTypeResolver<Params, Result> = SingleTypeResolver<
+    Params,
+    Result
+  >,
+> = UnresolvedSingleTag<Params, Result, Resolver> | ResolvedSingleTag<Result>;
+
+export type ResolvedSingleTag<Result extends string> = Tag<"single"> &
+  ResolvedTag<Result>;
+export type UnresolvedSingleTag<
+  Params extends SingleTagParameters = SingleTagParameters,
+  Result extends SingleTagResult = SingleTagResult,
+  Resolver extends SingleTypeResolver<Params, Result> = SingleTypeResolver<
+    Params,
+    Result
+  >,
+> = Tag<"single"> &
+  UnresolvedTag & {
+    resolver: Resolver;
+  };
+
+export type SingleTagParameters = any[];
+export type SingleTagResult = string;
+export type SingleTypeResolver<
+  Params extends SingleTagParameters = SingleTagParameters,
+  Result extends SingleTagResult = SingleTagResult,
+> = (...args: Params) => ResolvedSingleTag<Result>;
+
+// Hierarchy Tag Types
+export type HierarchyTag<
+  Tags extends readonly SingleTag[] = readonly SingleTag[],
+  Params extends HierarchyTagParameters<Tags> = HierarchyTagParameters<Tags>,
+  Result extends HierarchyTagResult<Tags> = HierarchyTagResult<Tags>,
+  Resolver extends HierarchyTagResolver<
+    Tags,
+    Params,
+    Result
+  > = HierarchyTagResolver<Tags, Params, Result>,
+> =
+  | UnresolvedHierarchyTag<Tags, Params, Result, Resolver>
+  | ResolvedHierarchyTag<Result>;
+
+export type ResolvedHierarchyTag<Result extends string[]> = Tag<"hierarchy"> &
+  ResolvedMultipleTag<Result>;
+
+export type UnresolvedHierarchyTag<
+  Tags extends readonly SingleTag[],
+  Params extends HierarchyTagParameters<Tags>,
+  Result extends HierarchyTagResult<Tags>,
+  Resolver extends HierarchyTagResolver<Tags, Params, Result>,
+> = Tag<"hierarchy"> &
+  UnresolvedTag & {
+    resolver: Resolver;
+  };
+
+export type HierarchyTagParameters<T extends readonly SingleTag[]> = T extends [
+  infer U,
+  ...infer V,
+]
+  ? V extends readonly SingleTag[]
+    ? U extends SingleTag
+      ? U extends ResolvedTag
+        ? CompositeTagParameters<V>
+        : U extends UnresolvedTag
+          ? [Parameters<U["resolver"]>, ...CompositeTagParameters<V>]
+          : never
+      : never
+    : U extends SingleTag
+      ? U extends UnresolvedTag
+        ? Parameters<U["resolver"]>
+        : never
+      : never
+  : [];
+
+export type HierarchyTagResult<
+  T extends readonly SingleTag[],
+  Prefix extends string = "",
+> = T extends [infer U, ...infer V]
+  ? V extends readonly SingleTag[]
+    ? U extends SingleTag
+      ? U extends ResolvedTag
+        ? [
+            Merge<Prefix, U["result"], "/">,
+            ...HierarchyTagResult<V, Merge<Prefix, U["result"], "/">>,
+          ]
+        : U extends UnresolvedTag
+          ? [
+              Merge<Prefix, ReturnType<U["resolver"]>["result"], "/">,
+              ...HierarchyTagResult<
+                V,
+                Merge<Prefix, ReturnType<U["resolver"]>["result"], "/">
+              >,
+            ]
+          : never
+      : never
+    : U extends SingleTag
+      ? U extends ResolvedTag
+        ? [Merge<Prefix, U["result"], "/">]
+        : U extends UnresolvedTag
+          ? [Merge<Prefix, ReturnType<U["resolver"]>["result"], "/">]
+          : never
+      : never
+  : [];
+
+export type HierarchyTagResolver<
+  Tags extends readonly SingleTag[],
+  Params extends HierarchyTagParameters<Tags>,
+  Result extends HierarchyTagResult<Tags>,
+> = (...args: Params) => ResolvedHierarchyTag<Result>;
+
+// Composite Tag Types
+export type CompositeTag<
+  Tags extends readonly SingleTag[] = readonly SingleTag[],
+  Params extends CompositeTagParameters<Tags> = CompositeTagParameters<Tags>,
+  Result extends CompositeTagResult<Tags> = CompositeTagResult<Tags>,
+  Resolver extends CompositeTagResolver<
+    Tags,
+    Params,
+    Result
+  > = CompositeTagResolver<Tags, Params, Result>,
+> =
+  | UnresolvedCompositeTag<Tags, Params, Result, Resolver>
+  | ResolvedCompositeTag<Result>;
+
+export type ResolvedCompositeTag<Result extends string> = Tag<"composite"> &
+  ResolvedTag<Result>;
+export type UnresolvedCompositeTag<
+  Tags extends readonly SingleTag[],
+  Params extends CompositeTagParameters<Tags>,
+  Result extends CompositeTagResult<Tags>,
+  Resolver extends CompositeTagResolver<Tags, Params, Result>,
+> = Tag<"composite"> &
+  UnresolvedTag & {
+    resolver: Resolver;
+  };
+
+export type CompositeTagParameters<T extends readonly SingleTag[]> = T extends [
+  infer U,
+  ...infer V,
+]
+  ? V extends readonly SingleTag[]
+    ? U extends SingleTag
+      ? U extends ResolvedTag
+        ? CompositeTagParameters<V>
+        : U extends UnresolvedTag
+          ? [Parameters<U["resolver"]>, ...CompositeTagParameters<V>]
+          : never
+      : never
+    : U extends SingleTag
+      ? U extends UnresolvedTag
+        ? Parameters<U["resolver"]>
+        : never
+      : never
+  : [];
+
+export type CompositeTagResult<
+  T extends readonly SingleTag[],
+  Prefix extends string = "",
+> = T extends [infer U, ...infer V]
+  ? V extends readonly SingleTag[]
+    ? U extends SingleTag
+      ? U extends ResolvedTag
+        ? CompositeTagResult<V, Merge<Prefix, U["result"], "_">>
+        : U extends UnresolvedTag
+          ? CompositeTagResult<
+              V,
+              Merge<Prefix, ReturnType<U["resolver"]>["result"], "_">
+            >
+          : never
+      : never
+    : U extends SingleTag
+      ? U extends ResolvedTag
+        ? Merge<Prefix, U["result"], "_">
+        : U extends UnresolvedTag
+          ? Merge<Prefix, ReturnType<U["resolver"]>["result"], "_">
+          : never
+      : never
+  : Prefix;
+
+export type CompositeTagResolver<
+  Tags extends readonly SingleTag[],
+  Params extends CompositeTagParameters<Tags>,
+  Result extends CompositeTagResult<Tags>,
+> = (...args: Params) => ResolvedCompositeTag<Result>;

--- a/packages/tag/tsconfig.json
+++ b/packages/tag/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "@h1y/next-loader-typescript-config/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": [
+      "jest",
+      "node"
+    ]
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/tag/tsup.config.mjs
+++ b/packages/tag/tsup.config.mjs
@@ -1,0 +1,7 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["cjs", "esm"],
+  dts: true,
+});


### PR DESCRIPTION
## 요약

- Type-Safe한 태그 라이브러리를 구성합니다.

## 작업 내용

- 일반 태그, 계층형 태그, 복합 태그를 생성할 수 있습니다.
- 타입 추론을 통해, 개발 환경에서 태그의 스키마를 유추하도록 합니다.
- 각각의 태그 함수에 대한 테스트 코드를 추가합니다.

## 범위

- @h1y/next-loader-tag (v1.0.0)
