### PR TITLE
fix(next-loader-tag): 테스트 로직 개선, 리드미 문서 개선 등

### DIFF
--- a/.changeset/ninety-icons-end.md
+++ b/.changeset/ninety-icons-end.md
@@ -1,0 +1,5 @@
+---
+"@h1y/next-loader-tag": patch
+---
+
+refactoring code, improving test logic, adding jsdoc, locating error messages to a single file

--- a/packages/next-loader-tag/docs/README-ko.md
+++ b/packages/next-loader-tag/docs/README-ko.md
@@ -1,35 +1,33 @@
 # @h1y/next-loader-tag
 
-A TypeScript library that provides a type-safe tag system. Supports static tags, dynamic tags, composite tags, and hierarchical tags.
+타입 안전한 태그 시스템을 제공하는 TypeScript 라이브러리입니다. 정적 태그, 동적 태그, 복합 태그, 계층적 태그를 지원합니다.
 
-[한국어 문서 (Korean Documentation)](./docs/README-ko.md)
-
-## Installation
+## 설치
 
 ```bash
 npm install @h1y/next-loader-tag
 ```
 
-## Usage
+## 사용법
 
-### Basic Tags
+### 기본 태그
 
 ```typescript
 import { tag } from "@h1y/next-loader-tag";
 
-// Static tag
+// 정적 태그
 const userTag = tag("user");
 console.log(userTag.result); // "user"
 
-// Dynamic tag
+// 동적 태그
 const dynamicTag = tag((id: number) => tag(`user-${id}`));
 const resolved = dynamicTag.resolver(123);
 console.log(resolved.result); // "user-123"
 ```
 
-### Composite Tags
+### 복합 태그 (Composite)
 
-Combine multiple tags with `_`.
+여러 태그를 `_`로 조합합니다.
 
 ```typescript
 import { tag, compose } from "@h1y/next-loader-tag";
@@ -43,9 +41,9 @@ const resolved = compositeTag.resolver([123]);
 console.log(resolved.result); // "app_user-123_click"
 ```
 
-### Hierarchical Tags
+### 계층적 태그 (Hierarchy)
 
-Connect multiple tags with `/` to create hierarchical structures.
+여러 태그를 `/`로 연결하여 계층 구조를 만듭니다.
 
 ```typescript
 import { tag, hierarchy } from "@h1y/next-loader-tag";
@@ -60,6 +58,6 @@ console.log(resolved.result);
 // ["api", "api/v1", "api/v1/users"]
 ```
 
-## License
+## 라이센스
 
 MIT

--- a/packages/next-loader-tag/src/__tests__/composite.test.ts
+++ b/packages/next-loader-tag/src/__tests__/composite.test.ts
@@ -2,147 +2,98 @@
 import { compose } from "../compose";
 import { tag } from "../tag";
 
-describe("composite 함수", () => {
-  describe("기본 기능", () => {
-    it("정적 태그들을 조합할 수 있다", () => {
-      const tag1 = tag("user");
-      const tag2 = tag("profile");
-      const tag3 = tag("view");
+describe("compose()", () => {
+  it("should create unresolved composite tag object", () => {
+    const tag1 = tag("user");
+    const tag2 = tag("profile");
+    const tag3 = tag("view");
 
-      const compositeTag = compose(tag1, tag2, tag3);
+    const compositeTag = compose(tag1, tag2, tag3);
 
-      expect(compositeTag.type).toBe("composite");
-      expect(compositeTag.resolved).toBe(false);
-      expect(typeof compositeTag.resolver).toBe("function");
-    });
-
-    it("정적 태그들을 조합하여 해결할 수 있다", () => {
-      const tag1 = tag("user");
-      const tag2 = tag("profile");
-
-      const compositeTag = compose(tag1, tag2);
-      const resolved = compositeTag.resolver();
-
-      expect(resolved.type).toBe("composite");
-      expect(resolved.resolved).toBe(true);
-      expect(resolved.result).toBe("user_profile");
-    });
-
-    it("동적 태그들을 조합할 수 있다", () => {
-      const userTag = tag((id: number) => tag(`user-${id}`));
-      const actionTag = tag(<T extends string>(action: T) =>
-        tag(`action-${action}`),
-      );
-
-      const compositeTag = compose(userTag, actionTag);
-      const resolved = compositeTag.resolver([123], ["click"]);
-
-      expect(resolved.result).toBe("user-123_action-click");
-    });
-
-    it("정적 태그와 동적 태그를 혼합하여 조합할 수 있다", () => {
-      const staticTag = tag("app");
-      const dynamicTag = tag((id: number) => tag(`user-${id}`));
-      const staticTag2 = tag("dashboard");
-
-      const compositeTag = compose(staticTag, dynamicTag, staticTag2);
-      const resolved = compositeTag.resolver([456]);
-
-      expect(resolved.result).toBe("app_user-456_dashboard");
-    });
+    expect(compositeTag.type).toBe("composite");
+    expect(compositeTag.resolved).toBe(false);
+    expect(typeof compositeTag.resolver).toBe("function");
   });
 
-  describe("복잡한 시나리오", () => {
-    it("여러 매개변수를 받는 동적 태그들을 조합할 수 있다", () => {
-      const userTag = tag(<T extends string>(namespace: T, id: number) =>
-        tag(`${namespace}-${id}`),
-      );
-      const actionTag = tag(<T extends string>(action: T, timestamp: number) =>
-        tag(`${action}-${timestamp}`),
-      );
+  it("should resolve composite with static tags", () => {
+    const tag1 = tag("user");
+    const tag2 = tag("profile");
 
-      const compositeTag = compose(userTag, actionTag);
-      const resolved = compositeTag.resolver(
-        ["app", 123],
-        ["click", 1234567890],
-      );
+    const compositeTag = compose(tag1, tag2);
+    const resolved = compositeTag.resolver();
 
-      expect(resolved.result).toBe("app-123_click-1234567890");
-    });
-
-    it("단일 태그도 조합할 수 있다", () => {
-      const singleTag = tag("standalone");
-
-      const compositeTag = compose(singleTag);
-      const resolved = compositeTag.resolver();
-
-      expect(resolved.result).toBe("standalone");
-    });
-
-    it("Generic을 활용한 정확한 타입 추론 테스트", () => {
-      const roleTag = tag(<T extends string>(role: T) => tag(`role:${role}`));
-      const actionTag = tag(<T extends string>(action: T) =>
-        tag(`action:${action}`),
-      );
-
-      const compositeTag = compose(roleTag, actionTag);
-      const resolved = compositeTag.resolver(["admin"], ["login"]);
-
-      expect(resolved.result).toBe("role:admin_action:login");
-    });
+    expect(resolved.type).toBe("composite");
+    expect(resolved.resolved).toBe(true);
+    expect(resolved.result).toBe("user_profile");
   });
 
-  describe("에러 처리", () => {
-    it("빈 태그 배열로 조합을 시도하면 에러가 발생한다", () => {
-      expect(() => {
-        (compose as any)();
-      }).toThrow("Error: at least a single tag required.");
-    });
+  it("should create composite with dynamic tags", () => {
+    const userTag = tag((id: number) => tag(`user-${id}`));
+    const actionTag = tag(<T extends string>(action: T) =>
+      tag(`action-${action}`),
+    );
 
-    it("동적 태그의 resolver가 실행 중 에러를 발생시키면 전파된다", () => {
-      const errorTag = tag((shouldError: boolean) => {
-        if (shouldError) {
-          throw new Error("Dynamic tag error");
-        }
-        return tag("success");
-      });
+    const compositeTag = compose(userTag, actionTag);
+    const resolved = compositeTag.resolver([123], ["click"]);
 
-      const compositeTag = compose(errorTag);
-
-      // 에러가 발생하는 경우
-      expect(() => compositeTag.resolver([true])).toThrow("Dynamic tag error");
-
-      // 정상 동작하는 경우
-      const resolved = compositeTag.resolver([false]);
-      expect(resolved.result).toBe("success");
-    });
+    expect(resolved.result).toBe("user-123_action-click");
   });
 
-  describe("실제 사용 시나리오", () => {
-    it("사용자 액션 추적 태그를 구성할 수 있다", () => {
-      const appTag = tag("myapp");
-      const userTag = tag((userId: number) => tag(`user-${userId}`));
-      const actionTag = tag(<T extends string>(action: T) =>
-        tag(`action-${action}`),
-      );
+  it("should create composite with mixed static and dynamic tags", () => {
+    const staticTag = tag("app");
+    const dynamicTag = tag((id: number) => tag(`user-${id}`));
+    const staticTag2 = tag("dashboard");
 
-      const trackingTag = compose(appTag, userTag, actionTag);
-      const resolved = trackingTag.resolver([123], ["button-click"]);
+    const compositeTag = compose(staticTag, dynamicTag, staticTag2);
+    const resolved = compositeTag.resolver([456]);
 
-      expect(resolved.result).toBe("myapp_user-123_action-button-click");
+    expect(resolved.result).toBe("app_user-456_dashboard");
+  });
+
+  it("should create composite with multi-parameter dynamic tags", () => {
+    const userTag = tag(<T extends string>(namespace: T, id: number) =>
+      tag(`${namespace}-${id}`),
+    );
+    const actionTag = tag(<T extends string>(action: T, timestamp: number) =>
+      tag(`${action}-${timestamp}`),
+    );
+
+    const compositeTag = compose(userTag, actionTag);
+    const resolved = compositeTag.resolver(["app", 123], ["click", 1234567890]);
+
+    expect(resolved.result).toBe("app-123_click-1234567890");
+  });
+
+  it("should create composite with single tag", () => {
+    const singleTag = tag("standalone");
+
+    const compositeTag = compose(singleTag);
+    const resolved = compositeTag.resolver();
+
+    expect(resolved.result).toBe("standalone");
+  });
+
+  it("should throw error with empty tag array", () => {
+    expect(() => {
+      (compose as any)();
+    }).toThrow("Error: at least a single tag required.");
+  });
+
+  it("should propagate errors from dynamic tag resolvers", () => {
+    const errorTag = tag((shouldError: boolean) => {
+      if (shouldError) {
+        throw new Error("Dynamic tag error");
+      }
+      return tag("success");
     });
 
-    it("계층적 네임스페이스 태그 구성", () => {
-      const orgTag = tag(<T extends string>(orgId: T) => tag(`org:${orgId}`));
-      const projectTag = tag(<T extends string>(projectId: T) =>
-        tag(`project:${projectId}`),
-      );
-      const resourceTag = tag("resource");
+    const compositeTag = compose(errorTag);
 
-      const resourcePathTag = compose(orgTag, projectTag, resourceTag);
-      const resolved = resourcePathTag.resolver(["acme"], ["web-app"]);
+    // Error case
+    expect(() => compositeTag.resolver([true])).toThrow("Dynamic tag error");
 
-      expect(resolved.result).toBe("org:acme_project:web-app_resource");
-    });
+    // Normal operation case
+    const resolved = compositeTag.resolver([false]);
+    expect(resolved.result).toBe("success");
   });
 });

--- a/packages/next-loader-tag/src/__tests__/composite.test.ts
+++ b/packages/next-loader-tag/src/__tests__/composite.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { compose } from "../compose";
+import { ERR_EMPTY_TAG_ARRAY } from "../errors";
 import { tag } from "../tag";
 
 describe("compose()", () => {
@@ -76,7 +77,7 @@ describe("compose()", () => {
   it("should throw error with empty tag array", () => {
     expect(() => {
       (compose as any)();
-    }).toThrow("Error: at least a single tag required.");
+    }).toThrow(ERR_EMPTY_TAG_ARRAY);
   });
 
   it("should propagate errors from dynamic tag resolvers", () => {

--- a/packages/next-loader-tag/src/__tests__/hierarchy.test.ts
+++ b/packages/next-loader-tag/src/__tests__/hierarchy.test.ts
@@ -2,257 +2,133 @@
 import { hierarchy } from "../hierarchy";
 import { tag } from "../tag";
 
-describe("hierarchy 함수", () => {
-  describe("기본 기능", () => {
-    it("정적 태그들을 계층적으로 조합할 수 있다", () => {
-      const tag1 = tag("category");
-      const tag2 = tag("subcategory");
-      const tag3 = tag("item");
+describe("hierarchy()", () => {
+  it("should create unresolved hierarchy tag object", () => {
+    const tag1 = tag("category");
+    const tag2 = tag("subcategory");
+    const tag3 = tag("item");
 
-      const hierarchyTag = hierarchy(tag1, tag2, tag3);
+    const hierarchyTag = hierarchy(tag1, tag2, tag3);
 
-      expect(hierarchyTag.type).toBe("hierarchy");
-      expect(hierarchyTag.resolved).toBe(false);
-      expect(typeof hierarchyTag.resolver).toBe("function");
-    });
-
-    it("정적 태그들을 계층적으로 조합하여 해결할 수 있다", () => {
-      const tag1 = tag("category");
-      const tag2 = tag("subcategory");
-      const tag3 = tag("item");
-
-      const hierarchyTag = hierarchy(tag1, tag2, tag3);
-      const resolved = hierarchyTag.resolver();
-
-      expect(resolved.type).toBe("hierarchy");
-      expect(resolved.resolved).toBe(true);
-      expect(resolved.result).toEqual([
-        "category",
-        "category/subcategory",
-        "category/subcategory/item",
-      ]);
-    });
-
-    it("동적 태그들을 계층적으로 조합할 수 있다", () => {
-      const categoryTag = tag((category: string) => tag(`cat-${category}`));
-      const itemTag = tag((item: string) => tag(`item-${item}`));
-
-      const hierarchyTag = hierarchy(categoryTag, itemTag);
-      const resolved = hierarchyTag.resolver(["electronics"], ["laptop"]);
-
-      expect(resolved.result).toEqual([
-        "cat-electronics",
-        "cat-electronics/item-laptop",
-      ]);
-    });
-
-    it("정적 태그와 동적 태그를 혼합하여 계층 구성할 수 있다", () => {
-      const rootTag = tag("store");
-      const categoryTag = tag((category: string) => tag(category));
-      const itemTag = tag("product");
-
-      const hierarchyTag = hierarchy(rootTag, categoryTag, itemTag);
-      const resolved = hierarchyTag.resolver(["books"]);
-
-      expect(resolved.result).toEqual([
-        "store",
-        "store/books",
-        "store/books/product",
-      ]);
-    });
+    expect(hierarchyTag.type).toBe("hierarchy");
+    expect(hierarchyTag.resolved).toBe(false);
+    expect(typeof hierarchyTag.resolver).toBe("function");
   });
 
-  describe("복잡한 시나리오", () => {
-    it("여러 매개변수를 받는 동적 태그들을 계층 구성할 수 있다", () => {
-      const orgTag = tag((org: string, region: string) =>
-        tag(`${org}-${region}`),
-      );
-      const deptTag = tag((dept: string, team: string) =>
-        tag(`${dept}-${team}`),
-      );
-      const resourceTag = tag("resource");
+  it("should resolve hierarchy with static tags", () => {
+    const tag1 = tag("category");
+    const tag2 = tag("subcategory");
+    const tag3 = tag("item");
 
-      const hierarchyTag = hierarchy(orgTag, deptTag, resourceTag);
-      const resolved = hierarchyTag.resolver(
-        ["acme", "us"],
-        ["engineering", "backend"],
-      );
+    const hierarchyTag = hierarchy(tag1, tag2, tag3);
+    const resolved = hierarchyTag.resolver();
 
-      expect(resolved.result).toEqual([
-        "acme-us",
-        "acme-us/engineering-backend",
-        "acme-us/engineering-backend/resource",
-      ]);
-    });
-
-    it("단일 태그도 계층 구조로 처리할 수 있다", () => {
-      const singleTag = tag("root");
-
-      const hierarchyTag = hierarchy(singleTag);
-      const resolved = hierarchyTag.resolver();
-
-      expect(resolved.result).toEqual(["root"]);
-    });
-
-    it("두 개의 태그로 계층 구조를 만들 수 있다", () => {
-      const parentTag = tag("parent");
-      const childTag = tag((child: string) => tag(child));
-
-      const hierarchyTag = hierarchy(parentTag, childTag);
-      const resolved = hierarchyTag.resolver(["child"]);
-
-      expect(resolved.result).toEqual(["parent", "parent/child"]);
-    });
-
-    it("Generic을 활용한 정확한 타입 추론 테스트", () => {
-      const namespaceTag = tag((ns: string) => tag(`ns:${ns}`));
-      const serviceTag = tag((service: string) => tag(`service:${service}`));
-      const versionTag = tag((version: string) => tag(`v${version}`));
-
-      const hierarchyTag = hierarchy(namespaceTag, serviceTag, versionTag);
-      const resolved = hierarchyTag.resolver(
-        ["production"],
-        ["api"],
-        ["2.1.0"],
-      );
-
-      expect(resolved.result).toEqual([
-        "ns:production",
-        "ns:production/service:api",
-        "ns:production/service:api/v2.1.0",
-      ]);
-    });
+    expect(resolved.type).toBe("hierarchy");
+    expect(resolved.resolved).toBe(true);
+    expect(resolved.result).toEqual([
+      "category",
+      "category/subcategory",
+      "category/subcategory/item",
+    ]);
   });
 
-  describe("에러 처리", () => {
-    it("빈 태그 배열로 계층 구성을 시도하면 에러가 발생한다", () => {
-      expect(() => {
-        (hierarchy as any)();
-      }).toThrow("Error: at least a single tag required.");
-    });
+  it("should create hierarchy with dynamic tags", () => {
+    const categoryTag = tag((category: string) => tag(`cat-${category}`));
+    const itemTag = tag((item: string) => tag(`item-${item}`));
 
-    it("동적 태그의 resolver가 실행 중 에러를 발생시키면 전파된다", () => {
-      const errorTag = tag((shouldError: boolean) => {
-        if (shouldError) {
-          throw new Error("Dynamic tag error");
-        }
-        return tag("success");
-      });
+    const hierarchyTag = hierarchy(categoryTag, itemTag);
+    const resolved = hierarchyTag.resolver(["electronics"], ["laptop"]);
 
-      const hierarchyTag = hierarchy(errorTag);
-
-      // 에러가 발생하는 경우
-      expect(() => hierarchyTag.resolver([true])).toThrow("Dynamic tag error");
-
-      // 정상 동작하는 경우
-      const resolved = hierarchyTag.resolver([false]);
-      expect(resolved.result).toEqual(["success"]);
-    });
+    expect(resolved.result).toEqual([
+      "cat-electronics",
+      "cat-electronics/item-laptop",
+    ]);
   });
 
-  describe("실제 사용 시나리오", () => {
-    it("파일 시스템 경로 구조를 생성할 수 있다", () => {
-      const rootTag = tag("home");
-      const userTag = tag((username: string) => tag(username));
-      const folderTag = tag("documents");
-      const fileTag = tag((filename: string) => tag(filename));
+  it("should create hierarchy with mixed static and dynamic tags", () => {
+    const rootTag = tag("store");
+    const categoryTag = tag((category: string) => tag(category));
+    const itemTag = tag("product");
 
-      const pathTag = hierarchy(rootTag, userTag, folderTag, fileTag);
-      const resolved = pathTag.resolver(["john"], ["report.pdf"]);
+    const hierarchyTag = hierarchy(rootTag, categoryTag, itemTag);
+    const resolved = hierarchyTag.resolver(["books"]);
 
-      expect(resolved.result).toEqual([
-        "home",
-        "home/john",
-        "home/john/documents",
-        "home/john/documents/report.pdf",
-      ]);
-    });
-
-    it("URL 경로 구조를 생성할 수 있다", () => {
-      const domainTag = tag("api.example.com");
-      const versionTag = tag("v1");
-      const resourceTag = tag((resource: string) => tag(resource));
-      const idTag = tag((id: number) => tag(id.toString()));
-
-      const urlTag = hierarchy(domainTag, versionTag, resourceTag, idTag);
-      const resolved = urlTag.resolver(["users"], [123]);
-
-      expect(resolved.result).toEqual([
-        "api.example.com",
-        "api.example.com/v1",
-        "api.example.com/v1/users",
-        "api.example.com/v1/users/123",
-      ]);
-    });
-
-    it("네임스페이스 기반 리소스 경로 구성", () => {
-      const clusterTag = tag((cluster: string) => tag(cluster));
-      const namespaceTag = tag((namespace: string) => tag(namespace));
-      const typeTag = tag("deployment");
-      const nameTag = tag((name: string) => tag(name));
-
-      const resourcePathTag = hierarchy(
-        clusterTag,
-        namespaceTag,
-        typeTag,
-        nameTag,
-      );
-      const resolved = resourcePathTag.resolver(
-        ["prod-cluster"],
-        ["backend"],
-        ["api-server"],
-      );
-
-      expect(resolved.result).toEqual([
-        "prod-cluster",
-        "prod-cluster/backend",
-        "prod-cluster/backend/deployment",
-        "prod-cluster/backend/deployment/api-server",
-      ]);
-    });
-
-    it("조직 구조 계층을 생성할 수 있다", () => {
-      const companyTag = tag("company");
-      const divisionTag = tag((division: string) => tag(division));
-      const departmentTag = tag((dept: string) => tag(dept));
-      const teamTag = tag((team: string) => tag(team));
-
-      const orgTag = hierarchy(companyTag, divisionTag, departmentTag, teamTag);
-      const resolved = orgTag.resolver(
-        ["engineering"],
-        ["backend"],
-        ["api-team"],
-      );
-
-      expect(resolved.result).toEqual([
-        "company",
-        "company/engineering",
-        "company/engineering/backend",
-        "company/engineering/backend/api-team",
-      ]);
-    });
+    expect(resolved.result).toEqual([
+      "store",
+      "store/books",
+      "store/books/product",
+    ]);
   });
 
-  describe("엣지 케이스", () => {
-    it("빈 문자열 태그도 계층에 포함할 수 있다", () => {
-      const rootTag = tag("");
-      const childTag = tag("child");
+  it("should create hierarchy with multi-parameter dynamic tags", () => {
+    const orgTag = tag((org: string, region: string) =>
+      tag(`${org}-${region}`),
+    );
+    const deptTag = tag((dept: string, team: string) => tag(`${dept}-${team}`));
+    const resourceTag = tag("resource");
 
-      const hierarchyTag = hierarchy(rootTag, childTag);
-      const resolved = hierarchyTag.resolver();
+    const hierarchyTag = hierarchy(orgTag, deptTag, resourceTag);
+    const resolved = hierarchyTag.resolver(
+      ["acme", "us"],
+      ["engineering", "backend"],
+    );
 
-      expect(resolved.result).toEqual(["", "child"]);
+    expect(resolved.result).toEqual([
+      "acme-us",
+      "acme-us/engineering-backend",
+      "acme-us/engineering-backend/resource",
+    ]);
+  });
+
+  it("should create hierarchy with single tag", () => {
+    const singleTag = tag("root");
+
+    const hierarchyTag = hierarchy(singleTag);
+    const resolved = hierarchyTag.resolver();
+
+    expect(resolved.result).toEqual(["root"]);
+  });
+
+  it("should throw error with empty tag array", () => {
+    expect(() => {
+      (hierarchy as any)();
+    }).toThrow("Error: at least a single tag required.");
+  });
+
+  it("should propagate errors from dynamic tag resolvers", () => {
+    const errorTag = tag((shouldError: boolean) => {
+      if (shouldError) {
+        throw new Error("Dynamic tag error");
+      }
+      return tag("success");
     });
 
-    it("동일한 값을 가진 태그들을 계층 구성할 수 있다", () => {
-      const tag1 = tag("same");
-      const tag2 = tag("same");
-      const tag3 = tag("same");
+    const hierarchyTag = hierarchy(errorTag);
 
-      const hierarchyTag = hierarchy(tag1, tag2, tag3);
-      const resolved = hierarchyTag.resolver();
+    // Error case
+    expect(() => hierarchyTag.resolver([true])).toThrow("Dynamic tag error");
 
-      expect(resolved.result).toEqual(["same", "same/same", "same/same/same"]);
-    });
+    // Normal operation case
+    const resolved = hierarchyTag.resolver([false]);
+    expect(resolved.result).toEqual(["success"]);
+  });
+
+  it("should create hierarchy with empty string tags", () => {
+    const rootTag = tag("");
+    const childTag = tag("child");
+
+    const hierarchyTag = hierarchy(rootTag, childTag);
+    const resolved = hierarchyTag.resolver();
+
+    expect(resolved.result).toEqual(["", "child"]);
+  });
+
+  it("should create hierarchy with identical value tags", () => {
+    const tag1 = tag("same");
+
+    const hierarchyTag = hierarchy(tag1, tag1, tag1);
+    const resolved = hierarchyTag.resolver();
+
+    expect(resolved.result).toEqual(["same", "same/same", "same/same/same"]);
   });
 });

--- a/packages/next-loader-tag/src/__tests__/hierarchy.test.ts
+++ b/packages/next-loader-tag/src/__tests__/hierarchy.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { ERR_EMPTY_TAG_ARRAY } from "../errors";
 import { hierarchy } from "../hierarchy";
 import { tag } from "../tag";
 
@@ -92,7 +93,7 @@ describe("hierarchy()", () => {
   it("should throw error with empty tag array", () => {
     expect(() => {
       (hierarchy as any)();
-    }).toThrow("Error: at least a single tag required.");
+    }).toThrow(ERR_EMPTY_TAG_ARRAY);
   });
 
   it("should propagate errors from dynamic tag resolvers", () => {

--- a/packages/next-loader-tag/src/__tests__/tag.test.ts
+++ b/packages/next-loader-tag/src/__tests__/tag.test.ts
@@ -1,3 +1,4 @@
+import { ERR_TAG_INVALID_INPUT } from "../errors";
 import { tag } from "../tag";
 
 describe("tag()", () => {
@@ -88,8 +89,7 @@ describe("tag()", () => {
 
   it("should throw error for invalid input types", () => {
     const invalidInputs = [123, null, undefined, [], {}];
-    const expectedError =
-      "Unexpected error: resolver is valid but doesn't match any known type.";
+    const expectedError = ERR_TAG_INVALID_INPUT;
 
     invalidInputs.forEach((input) => {
       expect(() => {

--- a/packages/next-loader-tag/src/compose.ts
+++ b/packages/next-loader-tag/src/compose.ts
@@ -1,3 +1,4 @@
+import { ERR_EMPTY_TAG_ARRAY } from "./errors";
 import {
   CompositeTagParameters,
   CompositeTagResolver,
@@ -6,6 +7,16 @@ import {
   UnresolvedCompositeTag,
 } from "./types";
 
+/**
+ * Creates a composite tag by combining the resolved string values of multiple individual tags.
+ * When resolved, the results of the individual tags are joined together with an underscore (`_`)
+ * to form a single, concatenated string.
+ *
+ * @param {Tags} tags - The individual `tag` instances you want to compose. You must provide at least one tag.
+ * @returns {UnresolvedCompositeTag<Tags, Params, Result, Resolver>} An unresolved composite tag object. When its resolver
+ *   function is called with the necessary arguments, it will produce the complete composed string.
+ * @throws {Error} If you call this function without providing any tags.
+ */
 export function compose<
   Tags extends readonly SingleTag[],
   Params extends CompositeTagParameters<Tags>,
@@ -13,7 +24,7 @@ export function compose<
   Resolver extends CompositeTagResolver<Tags, Params, Result>,
 >(...tags: Tags): UnresolvedCompositeTag<Tags, Params, Result, Resolver> {
   if (tags.length === 0) {
-    throw new Error("Error: at least a single tag required.");
+    throw new Error(ERR_EMPTY_TAG_ARRAY);
   }
 
   function resolve(...params: Params) {

--- a/packages/next-loader-tag/src/errors.ts
+++ b/packages/next-loader-tag/src/errors.ts
@@ -1,0 +1,2 @@
+export const ERR_TAG_INVALID_INPUT = `"tag" 함수에 제공된 값이 유효한 태그 결과나 리졸버 함수와 일치하지 않습니다. 내부 오류입니다.`;
+export const ERR_EMPTY_TAG_ARRAY = `태그 배열은 비어 있을 수 없습니다. 최소 하나의 태그가 필요합니다.`;

--- a/packages/next-loader-tag/src/hierarchy.ts
+++ b/packages/next-loader-tag/src/hierarchy.ts
@@ -1,3 +1,4 @@
+import { ERR_EMPTY_TAG_ARRAY } from "./errors";
 import {
   HierarchyTagParameters,
   HierarchyTagResolver,
@@ -6,6 +7,17 @@ import {
   UnresolvedHierarchyTag,
 } from "./types";
 
+/**
+ * Creates a hierarchy tag by combining multiple individual tags into a path-like structure.
+ * When resolved, the results of the individual tags are joined by a `/` to form a single hierarchical path.
+ * This is particularly useful for constructing dynamic URLs or file paths where each segment
+ * is derived from a separate tag.
+ *
+ * @param {Tags} tags - The individual `tag` instances you want to arrange hierarchically. You must provide at least one tag.
+ * @returns {UnresolvedHierarchyTag<Tags, Params, Result, Resolver>} An unresolved hierarchy tag object. When its resolver
+ *   function is called with the necessary arguments, it will produce the complete hierarchical path.
+ * @throws {Error} If you call this function without providing any tags.
+ */
 export function hierarchy<
   Tags extends readonly SingleTag[],
   Params extends HierarchyTagParameters<Tags>,
@@ -13,7 +25,7 @@ export function hierarchy<
   Resolver extends HierarchyTagResolver<Tags, Params, Result>,
 >(...tags: Tags): UnresolvedHierarchyTag<Tags, Params, Result, Resolver> {
   if (tags.length === 0) {
-    throw new Error("Error: at least a single tag required.");
+    throw new Error(ERR_EMPTY_TAG_ARRAY);
   }
 
   function resolve(...params: Params) {

--- a/packages/next-loader-tag/src/tag.ts
+++ b/packages/next-loader-tag/src/tag.ts
@@ -1,3 +1,4 @@
+import { ERR_TAG_INVALID_INPUT } from "./errors";
 import {
   ResolvedSingleTag,
   SingleTag,
@@ -7,16 +8,43 @@ import {
   UnresolvedSingleTag,
 } from "./types";
 
+/**
+ * Creates a single tag, which can either be a pre-resolved string value or a function that resolves
+ * to a string based on provided arguments. This function is overloaded to support both direct values
+ * and dynamic resolvers.
+ *
+ * @param {Resolver} resolver - A function that takes specific arguments (matching `Params`) and returns an object
+ *   with a `result` property, which is the final string value for the tag. Use this when the tag's value
+ *   needs to be dynamically generated at a later stage.
+ * @returns {UnresolvedSingleTag<Params, Result, Resolver>} An unresolved single tag object. Its value will be
+ *   determined by calling the provided resolver function with appropriate arguments later.
+ */
 export function tag<
   Params extends SingleTagParameters,
   Result extends SingleTagResult,
   Resolver extends SingleTagResolver<Params, Result>,
 >(resolver: Resolver): UnresolvedSingleTag<Params, Result, Resolver>;
 
+/**
+ * Creates a single tag with a directly provided string value, making it immediately resolved.
+ *
+ * @param {Result} tag - The direct string value for the tag. This value will be used as-is,
+ *   without any further processing or resolution.
+ * @returns {ResolvedSingleTag<Result>} A resolved single tag object, containing the provided string value.
+ */
 export function tag<Result extends SingleTagResult>(
   tag: Result,
 ): ResolvedSingleTag<Result>;
 
+/**
+ * Overload implementation for the `tag` function. It handles both direct string values and resolver functions
+ * to create a `SingleTag`.
+ *
+ * @param {Resolver | Result} value - Either a direct string value for an immediately resolved tag, or a function
+ *   that will resolve to a string value when called with appropriate parameters.
+ * @returns {SingleTag<Params, Result, Resolver>} A `SingleTag` object, which is either resolved with a direct result
+ *   or remains unresolved, containing a resolver function.
+ */
 export function tag<
   Params extends SingleTagParameters,
   Result extends SingleTagResult,
@@ -38,9 +66,7 @@ export function tag<
     };
   }
 
-  throw new Error(
-    "Unexpected error: resolver is valid but doesn't match any known type.",
-  );
+  throw new Error(ERR_TAG_INVALID_INPUT);
 }
 
 function isSingleTagResult(value: unknown): value is SingleTagResult {

--- a/packages/next-loader-tag/src/type-utils/join.ts
+++ b/packages/next-loader-tag/src/type-utils/join.ts
@@ -1,0 +1,9 @@
+export type Join<
+  Left extends string,
+  Right extends string,
+  Separator extends string,
+> = Left extends ""
+  ? Right
+  : Right extends ""
+    ? Left
+    : `${Left}${Separator}${Right}`;

--- a/packages/next-loader-tag/src/types.ts
+++ b/packages/next-loader-tag/src/types.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { Join } from "./type-utils/join";
 
 // Common Tag Types
 type UnresolvedTag = {
@@ -18,12 +19,6 @@ type ResolvedMultipleTag<T extends string[] = string[]> = {
 type TagType = "single" | "composite" | "hierarchy";
 type Tag<Type extends TagType> = { type: Type };
 
-type Merge<
-  T extends string,
-  U extends string,
-  Connection extends string,
-> = T extends "" ? U : `${T}${Connection}${U}`;
-
 // Single Tag
 export type SingleTag<
   Params extends SingleTagParameters = SingleTagParameters,
@@ -34,7 +29,7 @@ export type SingleTag<
   >,
 > = UnresolvedSingleTag<Params, Result, Resolver> | ResolvedSingleTag<Result>;
 
-export type ResolvedSingleTag<Result extends string> = Tag<"single"> &
+export type ResolvedSingleTag<Result extends SingleTagResult> = Tag<"single"> &
   ResolvedTag<Result>;
 export type UnresolvedSingleTag<
   Params extends SingleTagParameters = SingleTagParameters,
@@ -109,24 +104,24 @@ export type HierarchyTagResult<
     ? U extends SingleTag
       ? U extends ResolvedTag
         ? [
-            Merge<Prefix, U["result"], "/">,
-            ...HierarchyTagResult<V, Merge<Prefix, U["result"], "/">>,
+            Join<Prefix, U["result"], "/">,
+            ...HierarchyTagResult<V, Join<Prefix, U["result"], "/">>,
           ]
         : U extends UnresolvedTag
           ? [
-              Merge<Prefix, ReturnType<U["resolver"]>["result"], "/">,
+              Join<Prefix, ReturnType<U["resolver"]>["result"], "/">,
               ...HierarchyTagResult<
                 V,
-                Merge<Prefix, ReturnType<U["resolver"]>["result"], "/">
+                Join<Prefix, ReturnType<U["resolver"]>["result"], "/">
               >,
             ]
           : never
       : never
     : U extends SingleTag
       ? U extends ResolvedTag
-        ? [Merge<Prefix, U["result"], "/">]
+        ? [Join<Prefix, U["result"], "/">]
         : U extends UnresolvedTag
-          ? [Merge<Prefix, ReturnType<U["resolver"]>["result"], "/">]
+          ? [Join<Prefix, ReturnType<U["resolver"]>["result"], "/">]
           : never
       : never
   : [];
@@ -189,19 +184,19 @@ export type CompositeTagResult<
   ? V extends readonly SingleTag[]
     ? U extends SingleTag
       ? U extends ResolvedTag
-        ? CompositeTagResult<V, Merge<Prefix, U["result"], "_">>
+        ? CompositeTagResult<V, Join<Prefix, U["result"], "_">>
         : U extends UnresolvedTag
           ? CompositeTagResult<
               V,
-              Merge<Prefix, ReturnType<U["resolver"]>["result"], "_">
+              Join<Prefix, ReturnType<U["resolver"]>["result"], "_">
             >
           : never
       : never
     : U extends SingleTag
       ? U extends ResolvedTag
-        ? Merge<Prefix, U["result"], "_">
+        ? Join<Prefix, U["result"], "_">
         : U extends UnresolvedTag
-          ? Merge<Prefix, ReturnType<U["resolver"]>["result"], "_">
+          ? Join<Prefix, ReturnType<U["resolver"]>["result"], "_">
           : never
       : never
   : Prefix;


### PR DESCRIPTION
## 요약

- 불분명하고 의미없는 부분을 개선했습니다.

## 작업 내용

- 네이밍이 명확하지 않고 중복된 부분이 많았던 테스트 로직을 개선하였습니다.
- README 문서의 기본 언어를 영어로 하고, 한글 문서를 별도로 두었습니다.
- README 문서를 간소화하여 의미를 명확히 했습니다.
- 각 함수에 JSDoc을 추가했습니다.
- Error Message를 하나의 파일에 모아놓았습니다.

## 범위

- @h1y/next-loader-tag (v1.0.0)
