### PR TITLE
fix: changesets versioning 과정에서 생기는 미스매치 수정

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,7 +1,10 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
-  "changelog": ["@changesets/changelog-github", { "repo": "h1ylabs/next-loader" }],
-  "commit": true,
+  "changelog": [
+    "@changesets/changelog-github",
+    { "repo": "h1ylabs/next-loader" }
+  ],
+  "commit": ["../changesets.commit.mjs", { "skipCI": false }],
   "fixed": [],
   "linked": [],
   "access": "public",

--- a/changesets.commit.mjs
+++ b/changesets.commit.mjs
@@ -1,0 +1,19 @@
+import CommitFunction from "@commitlint/cli/commit";
+
+export default {
+  ...CommitFunction,
+  getVersionMessage,
+};
+
+const getVersionMessage = async (releasePlan) => {
+  const publishableReleases = releasePlan.releases.filter(
+    (release) => release.type !== "none",
+  );
+  const numPackagesReleased = publishableReleases.length;
+
+  const releasesLines = publishableReleases
+    .map((release) => `  ${release.name}@${release.newVersion}`)
+    .join("\n");
+
+  return `release: ${numPackagesReleased} version package(s)\n\nReleases:\n${releasesLines}`;
+};


### PR DESCRIPTION
## 요약

- changesets에서 versioning 과정에서 생기는 불편한 문제들을 수정했습니다.

## 작업 내용

- changesets에서 versioning 시 자동으로 생성되는 commit을 기존 convention에 맞추었습니다.
- versioning 과정에서 생기는 skip ci 커밋 메시지가 나오지 않도록 수정했습니다.

## 범위

- all
