### PR TITLE
hotfix: changesets 커밋 메시지 작성 함수를 직접 구현하도록 수정

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,7 +1,10 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
-  "changelog": ["@changesets/changelog-github", { "repo": "h1ylabs/next-loader" }],
-  "commit": true,
+  "changelog": [
+    "@changesets/changelog-github",
+    { "repo": "h1ylabs/next-loader" }
+  ],
+  "commit": ["../changesets.commit.mjs", { "skipCI": false }],
   "fixed": [],
   "linked": [],
   "access": "public",

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
     "@changesets/changelog-github",
     { "repo": "h1ylabs/next-loader" }
   ],
-  "commit": ["../changesets.commit.mjs", { "skipCI": false }],
+  "commit": ["../changesets.commit.mjs"],
   "fixed": [],
   "linked": [],
   "access": "public",

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
     "@changesets/changelog-github",
     { "repo": "h1ylabs/next-loader" }
   ],
-  "commit": ["../changesets.commit.mjs"],
+  "commit": ["../changesets.commit"],
   "fixed": [],
   "linked": [],
   "access": "public",

--- a/changesets.commit.mjs
+++ b/changesets.commit.mjs
@@ -1,8 +1,6 @@
-import CommitFunction from "@commitlint/cli/commit";
-
-export default {
-  ...CommitFunction,
-  getVersionMessage,
+// from: https://github.com/changesets/changesets/blob/main/packages/cli/src/commit/index.ts
+const getAddMessage = async (changeset) => {
+  return `docs(changeset): ${changeset.summary}`;
 };
 
 const getVersionMessage = async (releasePlan) => {
@@ -16,4 +14,9 @@ const getVersionMessage = async (releasePlan) => {
     .join("\n");
 
   return `release: ${numPackagesReleased} version package(s)\n\nReleases:\n${releasesLines}`;
+};
+
+export default {
+  getAddMessage,
+  getVersionMessage,
 };

--- a/changesets.commit.mjs
+++ b/changesets.commit.mjs
@@ -1,0 +1,19 @@
+import CommitFunction from "@commitlint/cli/commit";
+
+export default {
+  ...CommitFunction,
+  getVersionMessage,
+};
+
+const getVersionMessage = async (releasePlan) => {
+  const publishableReleases = releasePlan.releases.filter(
+    (release) => release.type !== "none",
+  );
+  const numPackagesReleased = publishableReleases.length;
+
+  const releasesLines = publishableReleases
+    .map((release) => `  ${release.name}@${release.newVersion}`)
+    .join("\n");
+
+  return `release: ${numPackagesReleased} version package(s)\n\nReleases:\n${releasesLines}`;
+};


### PR DESCRIPTION
## 요약

- @changesets/cli/commit을 참조하지 않고 직접 메시지 함수를 작성하도록 수정했습니다.

## 작업 내용

- @changesets/cli의 빌드 결과물에는 type만 포함되어 있고, 실제 JS 코드는 존재하지 않았습니다. 따라서, 해당 함수를 직접 구현하였습니다.

## 범위

- all
