### PR TITLE
fix: changesets 커밋 메시지 컨벤션 및 CI 생략 이슈

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,7 +1,10 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
-  "changelog": ["@changesets/changelog-github", { "repo": "h1ylabs/next-loader" }],
-  "commit": true,
+  "changelog": [
+    "@changesets/changelog-github",
+    { "repo": "h1ylabs/next-loader" }
+  ],
+  "commit": "../changesets.commit.mjs",
   "fixed": [],
   "linked": [],
   "access": "public",

--- a/changesets.commit.mjs
+++ b/changesets.commit.mjs
@@ -1,0 +1,22 @@
+// from: https://github.com/changesets/changesets/blob/main/packages/cli/src/commit/index.ts
+const getAddMessage = async (changeset) => {
+  return `docs(changeset): ${changeset.summary}`;
+};
+
+const getVersionMessage = async (releasePlan) => {
+  const publishableReleases = releasePlan.releases.filter(
+    (release) => release.type !== "none",
+  );
+  const numPackagesReleased = publishableReleases.length;
+
+  const releasesLines = publishableReleases
+    .map((release) => `  ${release.name}@${release.newVersion}`)
+    .join("\n");
+
+  return `release: ${numPackagesReleased} version package(s)\n\nReleases:\n${releasesLines}`;
+};
+
+export default {
+  getAddMessage,
+  getVersionMessage,
+};


### PR DESCRIPTION
## 요약

- Github Action Workflow에서 발생하는 커밋 컨벤션 불일치 및 CI 생략 이슈를 수정합니다.

## 작업 내용

- Changeset Versioning 시, @changesets/cli에서 제공하는 기본 커밋 메시지 대신 직접 메시지를 구성하였습니다.
- 커밋 컨벤션을 Commitlint에 맞게 수정하였습니다. (RELEASING: ... -> release: version packages)
- 자동으로 붙던 "skip ci"를 제거하여, Workflow에서 자동으로 배포가 수행되도록 했습니다.

## 범위

- ALL
