### PR TITLE
refactor: config 통합

### DIFF
--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -6,47 +6,52 @@ async function getInternalPackages() {
   const packageJsonPath = path.resolve("package.json");
   const packageJson = JSON.parse(await fs.readFile(packageJsonPath, "utf8"));
 
-  return await fg.glob(packageJson.workspaces ?? [], { onlyDirectories: true, deep: 1 });
+  return await fg.glob(packageJson.workspaces ?? [], {
+    onlyDirectories: true,
+    deep: 1,
+  });
 }
 
 async function getPackageNames(packages) {
   const packageNames = {};
-  
+
   for (const pkg of packages) {
     try {
       const pkgJsonPath = path.join(pkg, "package.json");
       const pkgJson = JSON.parse(await fs.readFile(pkgJsonPath, "utf8"));
       packageNames[pkg] = pkgJson.name || pkg;
     } catch (error) {
-      console.error(`[lint-staged] Error reading package.json for ${pkg}:`, error);
+      console.error(
+        `[lint-staged] Error reading package.json for ${pkg}:`,
+        error,
+      );
       packageNames[pkg] = pkg;
     }
   }
-  
+
   return packageNames;
 }
 
 async function generateConfig() {
   const internalPackages = await getInternalPackages();
   const packageNames = await getPackageNames(internalPackages);
-  
+
   console.log("[lint-staged] packages detected:", internalPackages);
 
-  // 각 패키지별로 설정 생성
+  // generate configuration for each package
   const config = {};
-  
-  // 각 패키지별 파일에 대한 규칙 설정
+
+  // set rules for files in each package
   for (const internalPackage of internalPackages) {
     const workspaceName = packageNames[internalPackage];
-    
-    // Linting 규칙
+
+    // linting rules
     config[`${internalPackage}/**/*.{ts,tsx}`] = [
       `yarn workspace ${workspaceName} lint`,
       `yarn workspace ${workspaceName} format:file`,
-      `yarn workspace ${workspaceName} check-types`
     ];
   }
-  
+
   return config;
 }
 

--- a/packages/loader-config/eslint/base.mjs
+++ b/packages/loader-config/eslint/base.mjs
@@ -1,0 +1,50 @@
+import js from "@eslint/js";
+import prettierPlugin from "eslint-config-prettier";
+import onlyWarnPlugin from "eslint-plugin-only-warn";
+import importSortPlugin from "eslint-plugin-simple-import-sort";
+import turboPlugin from "eslint-plugin-turbo";
+import ts from "typescript-eslint";
+
+// @ts-check
+export default ts.config(
+  // base plugin: ESLint, Prettier, TypeScript
+  js.configs.recommended,
+  ...ts.configs.recommended,
+  prettierPlugin,
+
+  // turborepo: eslint rules for turborepo options
+  {
+    plugins: {
+      turbo: turboPlugin,
+    },
+    rules: {
+      "turbo/no-undeclared-env-vars": "warn",
+    },
+  },
+
+  // simple-import-sort: automatically sorts import and export statements
+  {
+    plugins: {
+      "simple-import-sort": importSortPlugin,
+    },
+    rules: {
+      "simple-import-sort/imports": "error",
+      "simple-import-sort/exports": "error",
+    },
+  },
+
+  /**
+   * always shows warnings instead of errors for code formatting.
+   * INFO: use "--max-warnings=0" when running lint to enforce warnings as errors.
+   */
+  {
+    plugins: {
+      onlyWarn: onlyWarnPlugin,
+    },
+  },
+
+  // files to exclude from linting
+  {
+    ignores: ["node_modules/**", "dist/**", "build/**"],
+  },
+);

--- a/packages/loader-config/eslint/nextjs.mjs
+++ b/packages/loader-config/eslint/nextjs.mjs
@@ -1,0 +1,16 @@
+import nextJsPlugin from "@next/eslint-plugin-next";
+import reactUIConfig from "./react-ui.mjs";
+
+// @ts-check
+export default [
+  ...reactUIConfig,
+  {
+    plugins: {
+      "@next/next": nextJsPlugin,
+    },
+    rules: {
+      ...nextJsPlugin.configs.recommended.rules,
+      ...nextJsPlugin.configs["core-web-vitals"].rules,
+    },
+  },
+];

--- a/packages/loader-config/eslint/react-ui.mjs
+++ b/packages/loader-config/eslint/react-ui.mjs
@@ -1,0 +1,67 @@
+import jsxA11yPlugin from "eslint-plugin-jsx-a11y";
+import reactPlugin from "eslint-plugin-react";
+import readableTailwindPlugin from "eslint-plugin-readable-tailwind";
+import globals from "globals";
+import reactConfig from "./react.mjs";
+
+// @ts-check
+export default [
+  ...reactConfig,
+
+  // accessibility rules
+  {
+    files: ["**/*.{ts,tsx}"],
+    plugins: {
+      "jsx-a11y": jsxA11yPlugin,
+    },
+    languageOptions: {
+      ...reactPlugin.configs.flat.recommended.languageOptions,
+      globals: { ...globals.serviceworker, ...globals.browser },
+    },
+    settings: {
+      react: { version: "detect" },
+    },
+    rules: {
+      ...jsxA11yPlugin.flatConfigs.recommended.rules,
+
+      // checks if <img> elements have meaningful alt text
+      "jsx-a11y/alt-text": [
+        "error",
+        {
+          elements: ["img"],
+        },
+      ],
+
+      // only use valid aria-* attributes
+      "jsx-a11y/aria-props": "error",
+
+      // only use valid aria-* states/values
+      "jsx-a11y/aria-proptypes": "error",
+
+      // only use roles and ARIA supported by DOM
+      "jsx-a11y/aria-unsupported-elements": "error",
+
+      // checks if required ARIA attributes are missing
+      "jsx-a11y/role-has-required-aria-props": "error",
+
+      // ARIA attributes are only used in supported roles
+      "jsx-a11y/role-supports-aria-props": "error",
+    },
+  },
+
+  {
+    files: ["**/*.{ts,tsx}"],
+    plugins: {
+      "readable-tailwind": readableTailwindPlugin,
+    },
+    languageOptions: {
+      ...reactPlugin.configs.flat.recommended.languageOptions,
+      globals: { ...globals.browser, ...globals.serviceworker },
+    },
+    rules: {
+      ...readableTailwindPlugin.configs.warning.rules,
+      ...readableTailwindPlugin.configs.error.rules,
+      "readable-tailwind/multiline": ["error", { printWidth: 80 }],
+    },
+  },
+];

--- a/packages/loader-config/eslint/react.mjs
+++ b/packages/loader-config/eslint/react.mjs
@@ -1,0 +1,24 @@
+import reactQueryPlugin from "@tanstack/eslint-plugin-query";
+import reactPlugin from "eslint-plugin-react";
+import reactHooksPlugin from "eslint-plugin-react-hooks";
+import baseConfig from "./base.mjs";
+
+// @ts-check
+export default [
+  ...baseConfig,
+  ...reactQueryPlugin.configs["flat/recommended"],
+  reactPlugin.configs.flat.recommended,
+
+  {
+    plugins: {
+      "react-hooks": reactHooksPlugin,
+    },
+    settings: { react: { version: "detect" } },
+    rules: {
+      ...reactHooksPlugin.configs.recommended.rules,
+
+      // react scope no longer necessary with new JSX transform.
+      "react/react-in-jsx-scope": "off",
+    },
+  },
+];

--- a/packages/loader-config/jest/index.mjs
+++ b/packages/loader-config/jest/index.mjs
@@ -1,0 +1,18 @@
+/** @type {import('jest').Config} */
+export default {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  extensionsToTreatAsEsm: [".ts"],
+  testMatch: ["**/__tests__/**/*.test.ts", "**/?(*.)+(spec|test).ts"],
+  moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/src/$1",
+  },
+  transform: {
+    "^.+\\.ts$": [
+      "ts-jest",
+      {
+        useESM: true,
+      },
+    ],
+  },
+};

--- a/packages/loader-config/package.json
+++ b/packages/loader-config/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@h1y/loader-config",
+  "version": "0.0.0",
+  "type": "module",
+  "private": true,
+  "devDependencies": {
+    "@eslint/compat": "^1.2.9",
+    "@eslint/js": "^9.26.0",
+    "@next/eslint-plugin-next": "^15.3.0",
+    "@tanstack/eslint-plugin-query": "^5.74.7",
+    "eslint": "^9.26.0",
+    "eslint-config-prettier": "^10.1.1",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
+    "eslint-plugin-only-warn": "^1.1.0",
+    "eslint-plugin-react": "^7.37.4",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-readable-tailwind": "^2.1.1",
+    "eslint-plugin-simple-import-sort": "^12.1.1",
+    "eslint-plugin-turbo": "^2.5.0",
+    "globals": "^16.0.0",
+    "typescript": "^5.8.2",
+    "typescript-eslint": "^8.31.0"
+  }
+}

--- a/packages/loader-config/package.json
+++ b/packages/loader-config/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "private": true,
   "devDependencies": {
+    "@types/jest": "^29.5.14",
     "@eslint/compat": "^1.2.9",
     "@eslint/js": "^9.26.0",
     "@next/eslint-plugin-next": "^15.3.0",
@@ -18,6 +19,7 @@
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-turbo": "^2.5.0",
     "globals": "^16.0.0",
+    "tsup": "^8.5.0",
     "typescript": "^5.8.2",
     "typescript-eslint": "^8.31.0"
   }

--- a/packages/loader-config/tsup/index.mjs
+++ b/packages/loader-config/tsup/index.mjs
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default customTsupConfig();
+
+export function customTsupConfig(entries) {
+  return defineConfig({
+    entry: [
+      "src/index.ts",
+      ...(entries?.map((entry) => `src/${entry}/index.ts`) ?? []),
+    ],
+    format: ["cjs", "esm"],
+    dts: true,
+  });
+}

--- a/packages/loader-config/typescript/base.json
+++ b/packages/loader-config/typescript/base.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "incremental": false,
+    "isolatedModules": true,
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "moduleResolution": "bundler",
+    "noUncheckedIndexedAccess": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022",
+    "types": ["jest", "node"]
+  }
+}

--- a/packages/loader-config/typescript/nextjs.json
+++ b/packages/loader-config/typescript/nextjs.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./base.json",
+  "compilerOptions": {
+    "plugins": [{ "name": "next" }],
+    "jsx": "preserve",
+    "noEmit": true
+  }
+}

--- a/packages/loader-config/typescript/react.json
+++ b/packages/loader-config/typescript/react.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
+}

--- a/packages/loader-tag/eslint.config.mjs
+++ b/packages/loader-tag/eslint.config.mjs
@@ -1,3 +1,1 @@
-import config from "@h1y/next-loader-eslint-config/base";
-
-export default config;
+export { default } from "@h1y/loader-config/eslint/base.mjs";

--- a/packages/loader-tag/jest.config.mjs
+++ b/packages/loader-tag/jest.config.mjs
@@ -1,18 +1,1 @@
-/** @type {import('jest').Config} */
-export default {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  extensionsToTreatAsEsm: [".ts"],
-  testMatch: ["**/__tests__/**/*.test.ts", "**/?(*.)+(spec|test).ts"],
-  moduleNameMapper: {
-    "^@/(.*)$": "<rootDir>/src/$1",
-  },
-  transform: {
-    "^.+\\.ts$": [
-      "ts-jest",
-      {
-        useESM: true,
-      },
-    ],
-  },
-};
+export { default } from "@h1y/loader-config/jest/index.mjs";

--- a/packages/loader-tag/package.json
+++ b/packages/loader-tag/package.json
@@ -37,8 +37,7 @@
     "test": "jest --coverage"
   },
   "devDependencies": {
-    "@h1y/next-loader-eslint-config": "*",
-    "@h1y/next-loader-typescript-config": "*",
+    "@h1y/loader-config": "*",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.15.29",
     "jest": "^30.0.0",

--- a/packages/loader-tag/tsconfig.json
+++ b/packages/loader-tag/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@h1y/next-loader-typescript-config/tsconfig.base.json",
+  "extends": "@h1y/loader-config/typescript/base.json",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
@@ -9,10 +9,6 @@
         "./src/*"
       ]
     },
-    "types": [
-      "jest",
-      "node"
-    ]
   },
   "include": [
     "src"
@@ -20,5 +16,5 @@
   "exclude": [
     "node_modules",
     "dist"
-  ]
+  ],
 }

--- a/packages/loader-tag/tsup.config.mjs
+++ b/packages/loader-tag/tsup.config.mjs
@@ -1,7 +1,1 @@
-import { defineConfig } from "tsup";
-
-export default defineConfig({
-  entry: ["src/index.ts"],
-  format: ["cjs", "esm"],
-  dts: true,
-});
+export { default } from "@h1y/loader-config/tsup/index.mjs";

--- a/packages/next-loader/eslint.config.mjs
+++ b/packages/next-loader/eslint.config.mjs
@@ -1,3 +1,1 @@
-import config from "@h1y/next-loader-eslint-config/react";
-
-export default config;
+export { default } from "@h1y/loader-config/eslint/react.mjs";

--- a/packages/next-loader/package.json
+++ b/packages/next-loader/package.json
@@ -52,8 +52,7 @@
     "lint": "eslint --cache --max-warnings=0"
   },
   "devDependencies": {
-    "@h1y/next-loader-eslint-config": "*",
-    "@h1y/next-loader-typescript-config": "*",
+    "@h1y/loader-config": "*",
     "@types/node": "^22.15.17",
     "@types/react": ">=18.2.0",
     "@types/react-dom": "^18.2.0",

--- a/packages/next-loader/tsconfig.json
+++ b/packages/next-loader/tsconfig.json
@@ -1,8 +1,14 @@
 {
-  "extends": "@h1y/next-loader-typescript-config/tsconfig.react.json",
+  "extends": "@h1y/loader-config/typescript/react.json",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./src/*"
+      ]
+    },
   },
   "include": [
     "src"
@@ -10,5 +16,5 @@
   "exclude": [
     "node_modules",
     "dist"
-  ]
+  ],
 }

--- a/packages/next-loader/tsup.config.mjs
+++ b/packages/next-loader/tsup.config.mjs
@@ -1,7 +1,1 @@
-import { defineConfig } from "tsup";
-
-export default defineConfig({
-  entry: ["src/index.ts", "src/utils/index.ts"],
-  format: ["cjs", "esm"],
-  dts: true,
-});
+export { default } from "@h1y/loader-config/tsup/index.mjs";


### PR DESCRIPTION
## 요약

- 각 라이브러리에 존재하는 config를 공통 config 라이브러리에서 가져올 수 있도록 리팩토링합니다.

## 작업 내용

- tsconfig, eslint, jest, tsup 환경설정을 하나의 내부 라이브러리(@h1y/loader-config)에서 관리하도록 했습니다.
- next-loader, loader-tag 라이브러리의 config를 @h1y/loader-config를 참조하도록 수정했습니다.
- lint-staged에서 typescript 체크를 수행하지 않도록 수정했습니다.

## 범위

- ALL
