### PR TITLE
feat(promise-aop): around advice 개선 등

### DIFF
--- a/.changeset/new-shoes-cry.md
+++ b/.changeset/new-shoes-cry.md
@@ -1,0 +1,5 @@
+---
+"@h1y/promise-aop": major
+---
+
+dual around wrappers, AsyncContext.exit feature, and clearer error/fallback handling, etc.

--- a/packages/promise-aop/docs/README-ko.md
+++ b/packages/promise-aop/docs/README-ko.md
@@ -1,6 +1,6 @@
-# @h1y/promise-aop
+# Promise-AOP
 
-비동기 JavaScript를 위한 TypeScript-first AOP(Aspect-Oriented Programming) 프레임워크입니다. 타입 안전한 공유 컨텍스트, 섹션 단위 잠금 기반 병렬 처리, halt/continue 정책과 에러 집계, 의존성 기반 실행 순서를 제공합니다.
+비동기 JavaScript를 위한 TypeScript-first AOP(Aspect-Oriented Programming) 프레임워크입니다. 타입 안전한 공유 컨텍스트와 섹션 잠금, around advice를 통한 유연한 래퍼 조합, 설정 가능한 에러 처리(halt/continue와 집계), 의존성 기반 실행 순서를 제공합니다.
 
 [English README](../README.md)
 
@@ -73,13 +73,13 @@ pnpm add @h1y/promise-aop
 
 ### 어드바이스 타입
 
-| Type             | 언제 실행    | Parameters         | 주요 용도                                     |
-| ---------------- | ------------ | ------------------ | --------------------------------------------- |
-| `before`         | 타겟 이전    | `(context)`        | 검증, 초기화, 인증                            |
-| `around`         | 타겟을 래핑  | `(context, wrap)`  | 캐싱, 재시도, 시간 측정; 결과를 다루거나 대체 |
-| `afterReturning` | 성공 후      | `(context)`        | 성공 로그/정리                                |
-| `afterThrowing`  | 예외 발생 후 | `(context, error)` | 에러 로그/알림                                |
-| `after`          | 항상 마지막  | `(context)`        | 정리, 메트릭                                  |
+| Type             | 언제 실행    | Parameters                                      | 주요 용도                                 |
+| ---------------- | ------------ | ----------------------------------------------- | ----------------------------------------- |
+| `before`         | 타겟 이전    | `(context)`                                     | 검증, 초기화, 인증                        |
+| `around`         | 타겟을 래핑  | `(context, { attachToResult, attachToTarget })` | 캐싱, 재시도, 시간 측정; 유연한 래퍼 조합 |
+| `afterReturning` | 성공 후      | `(context)`                                     | 성공 로그/정리                            |
+| `afterThrowing`  | 예외 발생 후 | `(context, error)`                              | 에러 로그/알림                            |
+| `after`          | 항상 마지막  | `(context)`                                     | 정리, 메트릭                              |
 
 ### Aspect, Process, Context
 
@@ -160,7 +160,7 @@ const process = createProcess({
 
 ## 🧩 자주 쓰는 패턴
 
-### 캐싱 (fast‑path via `around`)
+### 유연한 래퍼 조합을 통한 캐싱
 
 ```ts
 type Data = { value: string };
@@ -177,8 +177,9 @@ const Cache = createAspect<Data, Ctx>((createAdvice) => ({
   name: "cache",
   around: createAdvice({
     use: ["cache"],
-    advice: async ({ cache }, wrap) => {
-      wrap((target) => async () => {
+    advice: async ({ cache }, { attachToTarget }) => {
+      // attachToTarget: 원본 타겟 함수에 직접 적용
+      attachToTarget((target) => async () => {
         const cached = await cache.get(key);
         if (cached) return cached;
         const out = await target();
@@ -254,11 +255,64 @@ const B = createAspect<string, { log: Console }>((createAdvice) => ({
 }));
 ```
 
+### 고급 Around Advice: 유연한 래퍼 조합
+
+v2 around advice는 최고의 유연성을 위해 두 가지 별개의 부착 지점을 제공합니다:
+
+```ts
+const AdvancedAround = createAspect<number, { log: Console }>(
+  (createAdvice) => ({
+    name: "advanced-around",
+    around: createAdvice({
+      use: ["log"],
+      advice: async ({ log }, { attachToResult, attachToTarget }) => {
+        // attachToTarget: 원본 타겟 함수에 적용
+        // 가장 안쪽에서 실행되어 실제 타겟에 가장 가깝게 위치
+        attachToTarget((target) => async () => {
+          log.info("target-wrapper: before");
+          const result = await target();
+          log.info("target-wrapper: after");
+          return result + 10;
+        });
+
+        // attachToResult: 최종 조합된 결과에 적용
+        // 가장 바깥쪽에서 실행되어 전체 체인을 래핑
+        attachToResult((target) => async () => {
+          log.info("result-wrapper: before");
+          const result = await target();
+          log.info("result-wrapper: after");
+          return result * 2;
+        });
+      },
+    }),
+  }),
+);
+
+// 타겟 값 5에 대한 실행 순서:
+// result-wrapper: before
+// target-wrapper: before
+// [원본 타겟 실행: 5]
+// target-wrapper: after  → 5 + 10 = 15
+// result-wrapper: after  → 15 * 2 = 30
+```
+
+#### 주요 차이점
+
+- **`attachToTarget`**: 원본 타겟 함수를 직접 래핑합니다. 여러 타겟 래퍼는 역순으로 조합됩니다(마지막에 부착된 것이 타겟 래퍼 중 가장 바깥쪽에서 실행).
+- **`attachToResult`**: 모든 타겟 래퍼가 적용된 후 전체 실행 체인을 래핑합니다. 결과 래퍼도 역순으로 조합됩니다.
+- **실행 순서**: `resultWrapper(nextChain(targetWrapper(target)))`
+
+이 설계는 다음과 같은 정교한 시나리오를 가능하게 합니다:
+
+- 타겟 레벨에서 캐싱하면서 결과 레벨에서 메트릭 추가
+- 타겟 래퍼를 통한 입력 검증/변환, 결과 래퍼를 통한 출력 포맷팅
+- 다계층 에러 처리 및 재시도 로직
+
 ---
 
 ## 📚 API 레퍼런스
 
-### Core Functions
+### Core functions
 
 | Function                                 | Description                                   | Returns                                     |
 | ---------------------------------------- | --------------------------------------------- | ------------------------------------------- |
@@ -266,7 +320,7 @@ const B = createAspect<string, { log: Console }>((createAdvice) => ({
 | `createProcess<Result, Context>(config)` | 어드바이스 체인을 실행 가능한 프로세스로 조합 | `Process<Result, Context>`                  |
 | `runProcess<Result, Context>(props)`     | 컨텍스트와 타겟을 받아 프로세스 실행          | `Promise<Result \| typeof TARGET_FALLBACK>` |
 
-### 타입 상세 (Core Functions에서 사용)
+### Type details (used by core functions)
 
 - Result: 타겟 함수의 반환 타입
 - Context / SharedContext: 모든 어드바이스에서 공유되는 불변 컨텍스트 객체
@@ -278,7 +332,7 @@ const B = createAspect<string, { log: Console }>((createAdvice) => ({
 - `AdviceFunction`, `AdviceFunctionWithContext`: 어드바이스 타입별 엄격한 시그니처
 - `Target<Result>`: `() => Promise<Result>` — 조인 포인트가 되는 타겟 함수
 - `TargetWrapper<Result>`: `(target: Target<Result>) => Target<Result>` — `around`에서 사용하는 래퍼
-- `Process<Result, Context>`: `(context: () => Context, target: Target<Result>) => Promise<Result | typeof TARGET_FALLBACK>`
+- `Process<Result, Context>`: `(context: () => Context, exit: <T>(callback: () => T) => T, target: Target<Result>) => Promise<Result | typeof TARGET_FALLBACK>`
 - `BuildOptions`(어드바이스별): 실행 전략과 에러 정책 (`ExecutionStrategy`, `AggregationUnit`, `ErrorAfter`)
 - `ProcessOptions<Result>`: `{ resolveHaltRejection, resolveContinuousRejection }`
 - `AsyncContext<Context>`와 `Restricted<Context, Sections>`: 실행마다 새 불변 컨텍스트 제공 및 섹션 단위 접근 제한 유틸리티
@@ -304,27 +358,48 @@ const process = createProcess<
 });
 ```
 
-### `around` 구성 순서
+### Around 래퍼 조합 순서
 
-- 먼저 등록된 `wrap`이 가장 안쪽(innermost)에 적용됩니다
+- **타겟 래퍼** (`attachToTarget` 사용): 마지막에 부착된 것이 타겟 래퍼 중 가장 바깥쪽에서 실행
+- **결과 래퍼** (`attachToResult` 사용): 마지막에 부착된 것이 결과 래퍼 중 가장 바깥쪽에서 실행
+- **전체 순서**: `resultWrapper(nextChain(targetWrapper(target)))`
 
 ### AsyncContext 통합
 
-```ts
-import { AsyncContext, createProcess } from "@h1y/promise-aop";
+Promise-AOP v2는 더 나은 컨텍스트 관리를 위해 완벽한 AsyncContext 통합을 제공합니다:
 
+```ts
+import { AsyncContext, createProcess, runProcess } from "@h1y/promise-aop";
+
+// 방법 1: runProcess와 직접 AsyncContext 사용
+const asyncContext = AsyncContext.create(() => ({
+  logger: console,
+  database: myDb,
+}));
+
+const result = await runProcess({
+  process: myProcess,
+  context: asyncContext, // AsyncContext를 직접 전달
+  target: async () => "Hello World",
+});
+
+// 방법 2: 수동 AsyncContext 실행 (고급 시나리오용)
 const process = createProcess({
   aspects: [
     /* ... */
   ],
 });
-const ac = AsyncContext.create(() => ({
-  /* context object */
-}));
-const out = await AsyncContext.execute(ac, (getCtx) =>
-  process(getCtx, async () => 42),
+const out = await AsyncContext.execute(asyncContext, (getCtx, exit) =>
+  process(getCtx, exit, async () => 42),
 );
 ```
+
+#### AsyncContext의 주요 장점
+
+- **자동 컨텍스트 전파**: 모든 비동기 작업에서 컨텍스트가 자동으로 흐름
+- **타입 안전성**: 컨텍스트 추론과 함께 완전한 TypeScript 지원
+- **메모리 효율성**: 컨텍스트가 실행 체인에 범위 지정됨
+- **격리**: 각 실행이 고유한 컨텍스트 인스턴스를 유지
 
 ### 에러 우선순위와 빠른 종료
 
@@ -358,6 +433,6 @@ yarn lint
 4. 브랜치를 푸시합니다 (`git push origin feature/amazing-feature`)
 5. Pull Request를 생성합니다
 
-## 📝 라이센스
+## 📝 License
 
-MIT
+MIT © [h1ylabs](https://github.com/h1ylabs)

--- a/packages/promise-aop/src/__tests__/integration.test.ts
+++ b/packages/promise-aop/src/__tests__/integration.test.ts
@@ -1,8 +1,11 @@
 import {
   createCommonTarget,
   createFailingTestTarget,
+  createFallbackProcessOptions,
   createLoggingContext,
   createLoggingTestAspect,
+  pickOrder,
+  runWith,
   StandardTestContext,
 } from "@/__tests__/test-utils";
 import {
@@ -44,8 +47,10 @@ describe("Integration – Promise-AOP", () => {
       const calls: string[] = [];
       const LoggingAspect = createLoggingTestAspect<number>();
 
-      const resolveHaltRejection = jest.fn().mockResolvedValue(TARGET_FALLBACK);
-      const resolveContinuousRejection = jest.fn();
+      const resolveHaltRejection = jest
+        .fn()
+        .mockResolvedValue(async () => TARGET_FALLBACK);
+      const resolveContinuousRejection = jest.fn().mockResolvedValue(undefined);
 
       const process = createProcess<number, StandardTestContext>({
         aspects: [LoggingAspect],
@@ -163,6 +168,210 @@ describe("Integration – Promise-AOP", () => {
         "afterReturning",
         "after",
       ]);
+    });
+  });
+
+  describe("Around Advice Features", () => {
+    it("should handle attachToResult and attachToTarget simultaneously", async () => {
+      const calls: string[] = [];
+
+      const TestAspect = createAspect<number, StandardTestContext>(
+        (createAdvice) => ({
+          name: "dual-attach-test",
+          around: createAdvice({
+            use: ["log"],
+            advice: async ({ log }, { attachToResult, attachToTarget }) => {
+              // Attach to result - applied to the final wrapped target
+              attachToResult((target) => async () => {
+                log.info("result-wrapper-start");
+                const result = await target();
+                log.info("result-wrapper-end");
+                return result * 2;
+              });
+
+              // Attach to target - applied to the original target
+              attachToTarget((target) => async () => {
+                log.info("target-wrapper-start");
+                const result = await target();
+                log.info("target-wrapper-end");
+                return result + 10;
+              });
+            },
+          }),
+        }),
+      );
+
+      const result = await runWith<number, StandardTestContext>([TestAspect], {
+        context: createLoggingContext(calls),
+        target: createCommonTarget(5),
+      });
+
+      // Expected execution order based on current architecture:
+      // resultWrapper(nextChain(targetWrapper(target)))
+      expect(result).toBe(30); // ((5 + 10) * 2)
+      expect(calls).toContain("result-wrapper-start");
+      expect(calls).toContain("result-wrapper-end");
+      expect(calls).toContain("target-wrapper-start");
+      expect(calls).toContain("target-wrapper-end");
+    });
+
+    it("should handle multiple attachToTarget wrappers in correct order", async () => {
+      const calls: string[] = [];
+
+      const MultiWrapperAspect = createAspect<number, StandardTestContext>(
+        (createAdvice) => ({
+          name: "multi-wrapper",
+          around: createAdvice({
+            use: ["log"],
+            advice: async ({ log }, { attachToTarget }) => {
+              attachToTarget((target) => async () => {
+                log.info("wrapper-1-start");
+                const result = await target();
+                log.info("wrapper-1-end");
+                return result + 1;
+              });
+
+              attachToTarget((target) => async () => {
+                log.info("wrapper-2-start");
+                const result = await target();
+                log.info("wrapper-2-end");
+                return result * 3;
+              });
+
+              attachToTarget((target) => async () => {
+                log.info("wrapper-3-start");
+                const result = await target();
+                log.info("wrapper-3-end");
+                return result + 100;
+              });
+            },
+          }),
+        }),
+      );
+
+      const result = await runWith<number, StandardTestContext>(
+        [MultiWrapperAspect],
+        { context: createLoggingContext(calls), target: createCommonTarget(2) },
+      );
+
+      // Expected execution order: wrapper-3(wrapper-2(wrapper-1(target)))
+      // wrapper-1(2) = 3, wrapper-2(3) = 9, wrapper-3(9) = 109
+      expect(result).toBe(109);
+
+      // Check execution order in logs
+      const wrapperStartOrder = pickOrder(calls, "-start");
+      const wrapperEndOrder = pickOrder(calls, "-end");
+
+      expect(wrapperStartOrder).toEqual([
+        "wrapper-3-start",
+        "wrapper-2-start",
+        "wrapper-1-start",
+      ]);
+      expect(wrapperEndOrder).toEqual([
+        "wrapper-1-end",
+        "wrapper-2-end",
+        "wrapper-3-end",
+      ]);
+    });
+
+    it("should handle complex async operations in wrappers", async () => {
+      const calls: string[] = [];
+
+      const AsyncAspect = createAspect<number, StandardTestContext>(
+        (createAdvice) => ({
+          name: "async-test",
+          around: createAdvice({
+            use: ["log"],
+            advice: async ({ log }, { attachToResult, attachToTarget }) => {
+              attachToResult((target) => async () => {
+                log.info("async-result-start");
+                await new Promise((resolve) => setTimeout(resolve, 1));
+                const result = await target();
+                await new Promise((resolve) => setTimeout(resolve, 1));
+                log.info("async-result-end");
+                return result + 1000;
+              });
+
+              attachToTarget((target) => async () => {
+                log.info("async-target-start");
+                const result = await target()
+                  .then((r) => r + 5)
+                  .then(async (r) => {
+                    await new Promise((resolve) => setTimeout(resolve, 1));
+                    return r * 2;
+                  });
+                log.info("async-target-end");
+                return result;
+              });
+            },
+          }),
+        }),
+      );
+
+      const result = await runWith<number, StandardTestContext>([AsyncAspect], {
+        context: createLoggingContext(calls),
+        target: createCommonTarget(3),
+      });
+
+      // Expected: ((3 + 5) * 2) + 1000 = 16 + 1000 = 1016
+      expect(result).toBe(1016);
+      expect(calls).toContain("async-result-start");
+      expect(calls).toContain("async-result-end");
+      expect(calls).toContain("async-target-start");
+      expect(calls).toContain("async-target-end");
+    });
+
+    it("should handle error scenarios with attachToTarget", async () => {
+      const calls: string[] = [];
+
+      const ErrorHandlingAspect = createAspect<number, StandardTestContext>(
+        (createAdvice) => ({
+          name: "error-handling",
+          around: createAdvice({
+            use: ["log"],
+            advice: async ({ log }, { attachToTarget }) => {
+              attachToTarget((target) => async () => {
+                log.info("error-wrapper-start");
+                try {
+                  const result = await target();
+                  log.info("error-wrapper-success");
+                  return result + 50;
+                } catch (error) {
+                  log.info("error-wrapper-caught");
+                  throw error;
+                }
+              });
+            },
+          }),
+          afterThrowing: createAdvice({
+            use: ["log"],
+            advice: async ({ log }, error) => {
+              log.info(
+                `afterThrowing: ${error instanceof Error ? error.message : String(error)}`,
+              );
+            },
+          }),
+        }),
+      );
+
+      const result = await runWith<number, StandardTestContext>(
+        [ErrorHandlingAspect],
+        {
+          context: createLoggingContext(calls),
+          target: createFailingTestTarget("target error"),
+          processOptions: createFallbackProcessOptions<
+            number,
+            StandardTestContext
+          >(),
+        },
+      );
+
+      expect(result).toBe(TARGET_FALLBACK);
+      expect(calls).toContain("error-wrapper-start");
+      expect(calls).toContain("error-wrapper-caught");
+      expect(calls.some((c) => c.includes("afterThrowing: target error"))).toBe(
+        true,
+      );
     });
   });
 });

--- a/packages/promise-aop/src/createProcess.ts
+++ b/packages/promise-aop/src/createProcess.ts
@@ -76,9 +76,10 @@ export function createProcess<Result, SharedContext>({
   const processOptions = normalizeProcessOptions(optionalProcessOptions);
   const advices = organizeAspect({ aspects, buildOptions });
 
-  return async (context, target) =>
+  return async (context, exit, target) =>
     executeAdviceChain<Result, SharedContext>({
       context,
+      exit,
       target,
       advices: await advices,
       buildOptions,
@@ -89,7 +90,7 @@ export function createProcess<Result, SharedContext>({
 export type __Props<Result, SharedContext> = {
   readonly aspects: readonly Aspect<Result, SharedContext>[];
   readonly buildOptions?: BuildOptions;
-  readonly processOptions?: ProcessOptions<Result>;
+  readonly processOptions?: ProcessOptions<Result, SharedContext>;
 };
 
 export type __Return<Result, SharedContext> = Process<Result, SharedContext>;

--- a/packages/promise-aop/src/lib/errors/AdviceError.ts
+++ b/packages/promise-aop/src/lib/errors/AdviceError.ts
@@ -5,9 +5,6 @@ export class AdviceError extends Error {
     public readonly advice: Advice,
     public readonly errors: unknown[],
   ) {
-    super(MSG_ERROR_ADVICE_NOT_CALLED_FROM_OUTSIDE);
+    super();
   }
 }
-
-export const MSG_ERROR_ADVICE_NOT_CALLED_FROM_OUTSIDE =
-  "AdviceError must not be called from outside.";

--- a/packages/promise-aop/src/lib/errors/HaltError.ts
+++ b/packages/promise-aop/src/lib/errors/HaltError.ts
@@ -1,9 +1,6 @@
 export class HaltError extends Error {
   constructor(error: unknown) {
-    super(MSG_ERROR_HALTED_ERROR);
+    super();
     this.cause = error;
   }
 }
-
-export const MSG_ERROR_HALTED_ERROR =
-  "HaltError must not be called from outside.";

--- a/packages/promise-aop/src/lib/errors/TargetError.ts
+++ b/packages/promise-aop/src/lib/errors/TargetError.ts
@@ -1,9 +1,6 @@
 export class TargetError extends Error {
   constructor(error: unknown) {
-    super(MSG_ERROR_TARGET_ERROR);
+    super();
     this.cause = error;
   }
 }
-
-export const MSG_ERROR_TARGET_ERROR =
-  "TargetError must not be called from outside.";

--- a/packages/promise-aop/src/lib/errors/UnknownError.ts
+++ b/packages/promise-aop/src/lib/errors/UnknownError.ts
@@ -1,9 +1,6 @@
 export class UnknownError extends Error {
   constructor(error: unknown) {
-    super(MSG_ERROR_UNKNOWN_ERROR);
+    super();
     this.cause = error;
   }
 }
-
-export const MSG_ERROR_UNKNOWN_ERROR =
-  "UnknownError must not be called from outside.";

--- a/packages/promise-aop/src/lib/errors/__tests__/AdviceError.test.ts
+++ b/packages/promise-aop/src/lib/errors/__tests__/AdviceError.test.ts
@@ -1,7 +1,4 @@
-import {
-  AdviceError,
-  MSG_ERROR_ADVICE_NOT_CALLED_FROM_OUTSIDE,
-} from "@/lib/errors/AdviceError";
+import { AdviceError } from "@/lib/errors/AdviceError";
 import type { Advice } from "@/lib/models/advice";
 
 describe("AdviceError", () => {
@@ -14,7 +11,6 @@ describe("AdviceError", () => {
     expect(adviceError).toBeInstanceOf(Error);
     expect(adviceError.advice).toBe(advice);
     expect(adviceError.errors).toBe(errors);
-    expect(adviceError.message).toBe(MSG_ERROR_ADVICE_NOT_CALLED_FROM_OUTSIDE);
   });
 
   it("should handle different advice types", () => {

--- a/packages/promise-aop/src/lib/errors/__tests__/HaltError.test.ts
+++ b/packages/promise-aop/src/lib/errors/__tests__/HaltError.test.ts
@@ -1,4 +1,4 @@
-import { HaltError, MSG_ERROR_HALTED_ERROR } from "@/lib/errors/HaltError";
+import { HaltError } from "@/lib/errors/HaltError";
 
 describe("HaltError", () => {
   it("should create a HaltError with error cause", () => {
@@ -8,7 +8,6 @@ describe("HaltError", () => {
 
     expect(haltError).toBeInstanceOf(Error);
     expect(haltError.cause).toBe(originalError);
-    expect(haltError.message).toBe(MSG_ERROR_HALTED_ERROR);
   });
 
   it("should handle string error", () => {
@@ -17,21 +16,18 @@ describe("HaltError", () => {
     const haltError = new HaltError(errorMessage);
 
     expect(haltError.cause).toBe(errorMessage);
-    expect(haltError.message).toBe(MSG_ERROR_HALTED_ERROR);
   });
 
   it("should handle null error", () => {
     const haltError = new HaltError(null);
 
     expect(haltError.cause).toBeNull();
-    expect(haltError.message).toBe(MSG_ERROR_HALTED_ERROR);
   });
 
   it("should handle undefined error", () => {
     const haltError = new HaltError(undefined);
 
     expect(haltError.cause).toBeUndefined();
-    expect(haltError.message).toBe(MSG_ERROR_HALTED_ERROR);
   });
 
   it("should handle complex object error", () => {
@@ -40,6 +36,5 @@ describe("HaltError", () => {
     const haltError = new HaltError(complexError);
 
     expect(haltError.cause).toBe(complexError);
-    expect(haltError.message).toBe(MSG_ERROR_HALTED_ERROR);
   });
 });

--- a/packages/promise-aop/src/lib/errors/__tests__/TargetError.test.ts
+++ b/packages/promise-aop/src/lib/errors/__tests__/TargetError.test.ts
@@ -1,4 +1,4 @@
-import { MSG_ERROR_TARGET_ERROR, TargetError } from "@/lib/errors/TargetError";
+import { TargetError } from "@/lib/errors/TargetError";
 
 describe("TargetError", () => {
   it("should create a TargetError with an error cause", () => {
@@ -7,7 +7,6 @@ describe("TargetError", () => {
 
     expect(targetError).toBeInstanceOf(Error);
     expect(targetError.cause).toBe(originalError);
-    expect(targetError.message).toBe(MSG_ERROR_TARGET_ERROR);
   });
 
   it("should handle a string error message", () => {

--- a/packages/promise-aop/src/lib/errors/__tests__/UnknownError.test.ts
+++ b/packages/promise-aop/src/lib/errors/__tests__/UnknownError.test.ts
@@ -1,7 +1,4 @@
-import {
-  MSG_ERROR_UNKNOWN_ERROR,
-  UnknownError,
-} from "@/lib/errors/UnknownError";
+import { UnknownError } from "@/lib/errors/UnknownError";
 
 describe("UnknownError", () => {
   it("should create an UnknownError with an error cause", () => {
@@ -10,7 +7,6 @@ describe("UnknownError", () => {
 
     expect(unknownError).toBeInstanceOf(Error);
     expect(unknownError.cause).toBe(originalError);
-    expect(unknownError.message).toBe(MSG_ERROR_UNKNOWN_ERROR);
   });
 
   it("should handle a string error message", () => {

--- a/packages/promise-aop/src/lib/features/chaining/__tests__/adviceHandlers.test.ts
+++ b/packages/promise-aop/src/lib/features/chaining/__tests__/adviceHandlers.test.ts
@@ -42,14 +42,17 @@ describe("adviceHandlers", () => {
   const createMockBuildOptions = (): RequiredBuildOptions =>
     defaultBuildOptions();
 
-  const createMockProcessOptions = (): RequiredProcessOptions<TestResult> =>
-    createProcessOptionsMock<TestResult>();
+  const createMockProcessOptions = (): RequiredProcessOptions<
+    TestResult,
+    TestSharedContext
+  > => createProcessOptionsMock<TestResult, TestSharedContext>();
 
   const createMockChainContext = (
     overrides: Partial<AdviceChainContext<TestResult, TestSharedContext>> = {},
   ): AdviceChainContext<TestResult, TestSharedContext> => ({
     target: createMockTarget(100),
     context: createMockContext(),
+    exit: <T>(callback: () => T) => callback(),
     advices: createMockAdvices(),
     buildOptions: createMockBuildOptions(),
     processOptions: createMockProcessOptions(),
@@ -137,7 +140,8 @@ describe("adviceHandlers", () => {
       await expect(handleTask(targetError)).rejects.toBeInstanceOf(HaltError);
 
       expect(context.haltRejection).toBeInstanceOf(HaltError);
-      expect(context.haltRejection?.cause).toBe(targetError);
+      // In the latest logic, TargetError is wrapped in UnknownError and stored in HaltError's cause.
+      expect(context.haltRejection?.cause).toBeInstanceOf(UnknownError);
       expect(context.continueRejections).toHaveLength(0);
     });
 

--- a/packages/promise-aop/src/lib/features/chaining/adviceHandlers.ts
+++ b/packages/promise-aop/src/lib/features/chaining/adviceHandlers.ts
@@ -1,6 +1,5 @@
 import { AdviceError } from "@/lib/errors/AdviceError";
 import { HaltError } from "@/lib/errors/HaltError";
-import { TargetError } from "@/lib/errors/TargetError";
 import { UnknownError } from "@/lib/errors/UnknownError";
 import { ErrorAfter } from "@/lib/models/buildOptions";
 import { exhaustiveCheckType, validateType } from "@/lib/utils/validateType";
@@ -45,10 +44,6 @@ export function handleRejection<Result, SharedContext>(
         default:
           exhaustiveCheckType(afterThrow);
       }
-    }
-    // 3. if error is thrown from target, halt immediately
-    else if (error instanceof TargetError) {
-      chain().haltRejection = new HaltError(error);
     }
 
     // 4. if error is unknown, halt immediately

--- a/packages/promise-aop/src/lib/features/chaining/context.ts
+++ b/packages/promise-aop/src/lib/features/chaining/context.ts
@@ -9,12 +9,13 @@ export type AdviceChainContext<Result, SharedContext> = {
   haltRejection?: HaltError;
   continueRejections: unknown[];
 
-  // default context
+  // functions for AsyncContext
   context: () => SharedContext;
+  exit: <T>(callback: () => T) => T;
 
-  // infomation for advice chain
+  // options for AdviceChain
   target: Target<Result>;
   advices: AspectOrganization<Result, SharedContext>;
   buildOptions: RequiredBuildOptions;
-  processOptions: RequiredProcessOptions<Result>;
+  processOptions: RequiredProcessOptions<Result, SharedContext>;
 };

--- a/packages/promise-aop/src/lib/features/chaining/rejectionHandlers.ts
+++ b/packages/promise-aop/src/lib/features/chaining/rejectionHandlers.ts
@@ -7,7 +7,13 @@ export function resolveHaltRejection<Result, SharedContext>(
 ) {
   return async (error: unknown) => {
     if (error instanceof HaltError) {
-      return chain().processOptions.resolveHaltRejection(error);
+      const fallback = await chain().processOptions.resolveHaltRejection(
+        chain().context,
+        chain().exit,
+        error.cause,
+      );
+
+      return fallback();
     }
 
     throw error;
@@ -19,6 +25,8 @@ export function handleContinuousRejection<Result, SharedContext>(
 ) {
   return async () => {
     chain().processOptions.resolveContinuousRejection(
+      chain().context,
+      chain().exit,
       chain().continueRejections,
     );
   };

--- a/packages/promise-aop/src/lib/features/processing/processAroundAdvice.ts
+++ b/packages/promise-aop/src/lib/features/processing/processAroundAdvice.ts
@@ -1,5 +1,11 @@
-import { AdviceFunctionWithContext } from "@/lib/models/advice";
-import { TargetWrapper } from "@/lib/models/target";
+import { AsyncLocalStorage } from "node:async_hooks";
+
+import type { AdviceFunctionWithContext } from "@/lib/models/advice";
+import type {
+  AroundAdviceResolver,
+  Target,
+  TargetWrapper,
+} from "@/lib/models/target";
 import { AsyncContext } from "@/lib/utils/AsyncContext";
 
 export async function processAroundAdvice<Result, SharedContext>({
@@ -7,28 +13,49 @@ export async function processAroundAdvice<Result, SharedContext>({
   around,
 }: __Props<Result, SharedContext>): Promise<__Return<Result>> {
   const ProcessContext = AsyncContext.create(
-    (): __ProcessContext<Result> => ({ wrappers: [] }),
+    (): __ProcessContext<Result> => ({
+      attachToResult: [],
+      attachToTarget: [],
+    }),
   );
 
   return AsyncContext.execute(ProcessContext, async (process) => {
     // collect wrappers
-    await around(context, (wrapper) => {
-      process().wrappers.push(wrapper);
+    await around(context, {
+      attachToResult(wrapper) {
+        process().attachToResult.push(wrapper);
+      },
+      attachToTarget(wrapper) {
+        process().attachToTarget.push(wrapper);
+      },
     });
 
-    // processing wrappers
-    return process().wrappers.reduce(
+    const resultAttacher = process().attachToResult.reduce(
       (wrapper, current) => (target) => current(wrapper(target)),
       (target) => target,
     );
+
+    const targetAttacher = process().attachToTarget.reduce(
+      (wrapper, current) => (target) => current(wrapper(target)),
+      (target) => target,
+    );
+
+    return (target) => (nextChain) => {
+      const snapshot = AsyncLocalStorage.snapshot();
+
+      return resultAttacher(snapshot(() => nextChain(targetAttacher(target))));
+    };
   });
 }
 
 export type __ProcessContext<Result> = {
-  readonly wrappers: TargetWrapper<Result>[];
+  readonly attachToResult: TargetWrapper<Result>[];
+  readonly attachToTarget: TargetWrapper<Result>[];
 };
 
-export type __Return<Result> = TargetWrapper<Result>;
+export type __Return<Result> = (
+  target: Target<Result>,
+) => AroundAdviceResolver<Result>;
 
 export type __Props<Result, SharedContext> = {
   readonly context: SharedContext;

--- a/packages/promise-aop/src/lib/models/advice.ts
+++ b/packages/promise-aop/src/lib/models/advice.ts
@@ -53,7 +53,15 @@ type CheckAdviceFn<T> = T extends (...args: never) => Promise<void> ? T : never;
 type AdviceFunctionMappings<Result> = {
   before: CheckAdviceFn<() => Promise<void>>;
   around: CheckAdviceFn<
-    (wrap: (wrap: TargetWrapper<Result>) => void) => Promise<void>
+    ({
+      attachToResult,
+      attachToTarget,
+    }: {
+      // Advice Chain을 결과물에 부착
+      attachToResult: (wrapper: TargetWrapper<Result>) => void;
+      // Advice Chain을 결과물 내 Target에 부착
+      attachToTarget: (wrapper: TargetWrapper<Result>) => void;
+    }) => Promise<void>
   >;
   afterReturning: CheckAdviceFn<() => Promise<void>>;
   afterThrowing: CheckAdviceFn<(error: unknown) => Promise<void>>;

--- a/packages/promise-aop/src/lib/models/process.ts
+++ b/packages/promise-aop/src/lib/models/process.ts
@@ -2,5 +2,6 @@ import type { Target, TARGET_FALLBACK } from "./target";
 
 export type Process<Result, SharedContext> = (
   context: () => SharedContext,
+  exit: <T>(callback: () => T) => T,
   target: Target<Result>,
 ) => Promise<Result | typeof TARGET_FALLBACK>;

--- a/packages/promise-aop/src/lib/models/target.ts
+++ b/packages/promise-aop/src/lib/models/target.ts
@@ -1,8 +1,18 @@
 export type Target<Result> = () => Promise<Result>;
 export type TargetWrapper<Result> = (target: Target<Result>) => Target<Result>;
+export type AroundAdviceResolver<Result> = (
+  nextChain: TargetWrapper<Result>,
+) => Target<Result>;
 
 // fallback of the target
 export const TARGET_FALLBACK = Symbol("PROMISE_AOP_TARGET_FALLBACK");
 
 export type TargetFallback = Target<typeof TARGET_FALLBACK>;
 export const TargetFallback: TargetFallback = async () => TARGET_FALLBACK;
+
+export type AroundAdviceFallbackResolver = AroundAdviceResolver<
+  typeof TARGET_FALLBACK
+>;
+export const AroundAdviceFallbackResolver: AroundAdviceFallbackResolver = (
+  chain,
+) => chain(TargetFallback);

--- a/packages/promise-aop/src/lib/utils/AsyncContext.ts
+++ b/packages/promise-aop/src/lib/utils/AsyncContext.ts
@@ -16,23 +16,37 @@ export class AsyncContext<SharedContext> {
     return store;
   };
 
+  public exit = <T>(callback: () => T) => {
+    return this.contextStore.exit(callback);
+  };
+
   static async execute<P, Q>(
-    { contextGenerator, contextStore, context }: AsyncContext<P>,
-    operation: (context: AsyncContext<P>["context"]) => Promise<Q>,
+    { contextGenerator, contextStore, context, exit }: AsyncContext<P>,
+    operation: (
+      context: AsyncContext<P>["context"],
+      exit: AsyncContext<P>["exit"],
+    ) => Promise<Q>,
   ): Promise<Q> {
     if (!contextGenerator) {
       throw new Error(MSG_ERR_ASYNC_CONTEXT_GENERATOR_NOT_PROVIDED);
     }
 
-    return contextStore.run(contextGenerator(), async () => operation(context));
+    return contextStore.run(contextGenerator(), async () =>
+      operation(context, exit),
+    );
   }
 
   static async executeWith<P, Q>(
-    { contextStore, context }: AsyncContext<P>,
+    { contextStore, context, exit }: AsyncContext<P>,
     contextGenerator: () => P,
-    operation: (context: AsyncContext<P>["context"]) => Promise<Q>,
+    operation: (
+      context: AsyncContext<P>["context"],
+      exit: AsyncContext<P>["exit"],
+    ) => Promise<Q>,
   ): Promise<Q> {
-    return contextStore.run(contextGenerator(), async () => operation(context));
+    return contextStore.run(contextGenerator(), async () =>
+      operation(context, exit),
+    );
   }
 
   static create<T>(contextGenerator?: () => T) {

--- a/packages/promise-aop/src/runProcess.ts
+++ b/packages/promise-aop/src/runProcess.ts
@@ -10,8 +10,8 @@ export async function runProcess<Result, SharedContext>({
   const asyncContext =
     typeof context === "function" ? AsyncContext.create(context) : context;
 
-  return AsyncContext.execute(asyncContext, async (ctx) =>
-    process(ctx, target),
+  return AsyncContext.execute(asyncContext, async (ctx, exit) =>
+    process(ctx, exit, target),
   );
 }
 


### PR DESCRIPTION
## 요약

- v1.0.0 -> v2.0.0 (BREAKING CHANGE)
-  exit 기능 및 target 에러 전파 전략 수정 등을 통해 v1 대비 안정성을 강화하였습니다.
- around advice의 구성 방식을 개편하여, 워크플로우와 결과물의 관계를 더욱 유연하게 구성할 수 있도록 했습니다.

## 작업 내용

- around advice의 방식을 attachToTarget(기존 방식), attachToResult 두 가지로 구성하였습니다.
- resolveHaltRejection에서, HaltError 대신 실제 에러를 내보내도록 변경하였습니다.
- afterThrowing advice 이후 무조건 target error를 전파하도록 전략을 수정하였습니다.
- exit 기능을 통해 불필요하게 공통 컨텍스트를 가지고 있지 않도록 했습니다.
- 내부에서만 사용되는 에러(AdviceError, HaltError 등)에 대해, 에러 메시지를 제거하였습니다.

## 범위

- @h1y/promise-aop (v1.0.0 -> v2.0.0)
