### PR TITLE
fix: prettier auto formatting using project config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,7 @@
-export default {
+{
   "printWidth": 80,
   "semi": true,
   "singleQuote": false,
   "tabWidth": 2,
-  "trailingComma": "all",
+  "trailingComma": "all"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,17 +6,12 @@
     "source.fixAll.eslint": "always",
     "source.organizeImports": "always"
   },
-  "markdownlint.config": {
-    "MD009": false,
-    "MD041": false
-  },
   "eslint.validate": [
     "javascript",
     "javascriptreact",
     "typescript",
     "typescriptreact"
   ],
-  "eslint.format.enable": true,
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
@@ -32,4 +27,6 @@
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "prettier.requireConfig": true,
+  "prettier.useEditorConfig": false,
 }

--- a/packages/next-loader/src/types/next-env.d.ts
+++ b/packages/next-loader/src/types/next-env.d.ts
@@ -10,7 +10,7 @@ declare global {
   // Next.js fetch 타입 정의
   function fetch(
     input: RequestInfo | URL,
-    init?: RequestInit
+    init?: RequestInit,
   ): Promise<Response>;
 }
 

--- a/packages/promise-aop/src/__tests__/integration.test.ts
+++ b/packages/promise-aop/src/__tests__/integration.test.ts
@@ -103,7 +103,7 @@ describe("Integration – Promise-AOP", () => {
               log.info("afterReturning:executed");
             },
           }),
-        })
+        }),
       );
 
       const process = createProcess<number, StandardTestContext>({
@@ -191,11 +191,11 @@ describe("Integration – Promise-AOP", () => {
       const context = () =>
         ({
           log: { info: jest.fn(), error: jest.fn() },
-        } as StandardTestContext);
+        }) as StandardTestContext;
       const target = createCommonTarget<number>(0);
 
       await expect(runProcess({ process, context, target })).rejects.toThrow(
-        /Section conflict:/
+        /Section conflict:/,
       );
     });
   });
@@ -254,7 +254,7 @@ describe("Integration – Promise-AOP", () => {
               });
             },
           }),
-        })
+        }),
       );
 
       const result = await runWith<number, StandardTestContext>([TestAspect], {
@@ -302,12 +302,12 @@ describe("Integration – Promise-AOP", () => {
               });
             },
           }),
-        })
+        }),
       );
 
       const result = await runWith<number, StandardTestContext>(
         [MultiWrapperAspect],
-        { context: createLoggingContext(calls), target: createCommonTarget(2) }
+        { context: createLoggingContext(calls), target: createCommonTarget(2) },
       );
 
       // Expected execution order: wrapper-3(wrapper-2(wrapper-1(target)))
@@ -361,7 +361,7 @@ describe("Integration – Promise-AOP", () => {
               });
             },
           }),
-        })
+        }),
       );
 
       const result = await runWith<number, StandardTestContext>([AsyncAspect], {
@@ -405,11 +405,11 @@ describe("Integration – Promise-AOP", () => {
               log.info(
                 `afterThrowing: ${
                   error instanceof Error ? error.message : String(error)
-                }`
+                }`,
               );
             },
           }),
-        })
+        }),
       );
 
       const expectedFallback = -1000;
@@ -425,14 +425,14 @@ describe("Integration – Promise-AOP", () => {
               .fn()
               .mockResolvedValue(async () => expectedFallback),
           },
-        }
+        },
       );
 
       expect(result).toBe(expectedFallback);
       expect(calls).toContain("error-wrapper-start");
       expect(calls).toContain("error-wrapper-caught");
       expect(calls.some((c) => c.includes("afterThrowing: target error"))).toBe(
-        true
+        true,
       );
     });
   });

--- a/packages/promise-aop/src/__tests__/test-utils.ts
+++ b/packages/promise-aop/src/__tests__/test-utils.ts
@@ -40,12 +40,12 @@ export interface StandardTestContext {
  * Creates a unified chain context for testing advice chains
  */
 export const createTestChain = <Result, SharedContext>(
-  overrides: Partial<AdviceChainContext<Result, SharedContext>> = {}
+  overrides: Partial<AdviceChainContext<Result, SharedContext>> = {},
 ): (() => AdviceChainContext<Result, SharedContext>) => {
   const state = {
     haltRejection: undefined,
     continueRejections: [] as unknown[],
-    context: () => ({} as SharedContext),
+    context: () => ({}) as SharedContext,
     target: (async () => "OK") as Target<Result>,
     advices: {
       before: jest.fn(async () => {}),
@@ -66,7 +66,7 @@ export const createTestChain = <Result, SharedContext>(
  * Creates a standard test context instance
  */
 export const createStandardTestContext = (
-  overrides: Partial<StandardTestContext> = {}
+  overrides: Partial<StandardTestContext> = {},
 ): StandardTestContext => ({
   log: {
     info: jest.fn(),
@@ -102,7 +102,7 @@ export const createLoggingContext =
  * Creates a reusable logging aspect for testing
  */
 export const createLoggingTestAspect = <Result>(
-  name = "logging"
+  name = "logging",
 ): Aspect<Result, StandardTestContext> =>
   createAspect<Result, StandardTestContext>((createAdvice) => ({
     name,
@@ -142,7 +142,7 @@ export const createLoggingTestAspect = <Result>(
 export const createFailingTestAspect = <Result>(
   name = "failing",
   phase: keyof Aspect<Result, StandardTestContext> = "before",
-  errorMessage = "test error"
+  errorMessage = "test error",
 ): Aspect<Result, StandardTestContext> =>
   createAspect<Result, StandardTestContext>((createAdvice) => ({
     name,
@@ -190,7 +190,7 @@ export const createIdDataContext =
  * Creates a default mock advices object, allowing selective overrides
  */
 export const createCommonAdvices = <Result, SharedContext>(
-  overrides: Partial<AspectOrganization<Result, SharedContext>> = {}
+  overrides: Partial<AspectOrganization<Result, SharedContext>> = {},
 ): AspectOrganization<Result, SharedContext> => ({
   before: jest.fn(),
   around: jest.fn(),
@@ -204,12 +204,12 @@ export const createCommonAdvices = <Result, SharedContext>(
  * Creates a mocked RequiredProcessOptions with jest fns, allowing overrides
  */
 export const createProcessOptionsMock = <Result, SharedContext>(
-  overrides: Partial<RequiredProcessOptions<Result, SharedContext>> = {}
+  overrides: Partial<RequiredProcessOptions<Result, SharedContext>> = {},
 ): RequiredProcessOptions<Result, SharedContext> => ({
   resolveHaltRejection: jest
     .fn()
     .mockResolvedValue(() =>
-      Promise.reject(new Error("Default mock - should be overridden in tests"))
+      Promise.reject(new Error("Default mock - should be overridden in tests")),
     ),
   resolveContinuousRejection: jest.fn().mockResolvedValue(undefined),
   ...overrides,
@@ -223,7 +223,7 @@ export async function runWith<Result, Ctx>(
     target: Target<Result>;
     buildOptions?: BuildOptions;
     processOptions?: ProcessOptions<Result, Ctx>;
-  }
+  },
 ) {
   const process = createProcess<Result, Ctx>({
     aspects,
@@ -235,7 +235,7 @@ export async function runWith<Result, Ctx>(
 
 // Standard fallback process options for tests
 export const createFallbackProcessOptions = <Result, SharedContext>(
-  fallbackValue?: Result
+  fallbackValue?: Result,
 ) =>
   createProcessOptionsMock<Result, SharedContext>({
     resolveHaltRejection: jest
@@ -249,7 +249,7 @@ export const wrapTargetWithLogs =
   <R>(
     log: { info: (s: string) => void },
     label: string,
-    map: (r: R) => R = (r) => r
+    map: (r: R) => R = (r) => r,
   ): TargetWrapper<R> =>
   (target) =>
   async () => {

--- a/packages/promise-aop/src/createAspect.ts
+++ b/packages/promise-aop/src/createAspect.ts
@@ -4,17 +4,17 @@ import type { SectionsUsed } from "@/lib/utils/RestrictedContext";
 
 type AdviceGeneratorHelper<Result, SharedContext> = <
   const Sections extends SectionsUsed<SharedContext>,
-  AdviceType extends Advice
+  AdviceType extends Advice,
 >(
-  advice: AdviceMetadata<Result, SharedContext, AdviceType, Sections>
+  advice: AdviceMetadata<Result, SharedContext, AdviceType, Sections>,
 ) => AdviceMetadata<Result, SharedContext, AdviceType, Sections>;
 
 type AspectGeneratorHelper<Result, SharedContext> = (
-  helper: AdviceGeneratorHelper<Result, SharedContext>
+  helper: AdviceGeneratorHelper<Result, SharedContext>,
 ) => Aspect<Result, SharedContext>;
 
 export function createAspect<Result, SharedContext>(
-  helper: AspectGeneratorHelper<Result, SharedContext>
+  helper: AspectGeneratorHelper<Result, SharedContext>,
 ): Aspect<Result, SharedContext> {
   return helper((generator) => generator);
 }

--- a/packages/promise-aop/src/lib/features/chaining/__tests__/adviceHandlers.test.ts
+++ b/packages/promise-aop/src/lib/features/chaining/__tests__/adviceHandlers.test.ts
@@ -49,7 +49,7 @@ describe("adviceHandlers", () => {
   > => createProcessOptionsMock<TestResult, TestSharedContext>();
 
   const createMockChainContext = (
-    overrides: Partial<AdviceChainContext<TestResult, TestSharedContext>> = {}
+    overrides: Partial<AdviceChainContext<TestResult, TestSharedContext>> = {},
   ): AdviceChainContext<TestResult, TestSharedContext> => ({
     target: createMockTarget(100),
     context: createMockContext(),
@@ -122,7 +122,7 @@ describe("adviceHandlers", () => {
 
         // This should set haltRejection and then throw it
         await expect(handleTask(rejection)).rejects.toBeInstanceOf(
-          HaltRejection
+          HaltRejection,
         );
         expect(context.haltRejection).toBeInstanceOf(HaltRejection);
         expect(context.haltRejection?.info).toBe(rejection.info);
@@ -149,7 +149,7 @@ describe("adviceHandlers", () => {
         expect(context.haltRejection).toBeUndefined();
         expect(context.continueRejections).toHaveLength(1);
         expect(context.continueRejections[0]).toBeInstanceOf(
-          ContinuousRejection
+          ContinuousRejection,
         );
         expect(context.continueRejections[0]?.info).toBe(rejection.info);
       });
@@ -162,7 +162,7 @@ describe("adviceHandlers", () => {
 
       const handleTask = handleRejection(chain);
       await expect(handleTask(unknownError)).rejects.toBeInstanceOf(
-        HaltRejection
+        HaltRejection,
       );
 
       expect(context.haltRejection).toBeInstanceOf(HaltRejection);
@@ -178,7 +178,7 @@ describe("adviceHandlers", () => {
 
       const handleTask = handleRejection(chain);
       await expect(handleTask(unknownError)).rejects.toBeInstanceOf(
-        HaltRejection
+        HaltRejection,
       );
 
       expect(context.haltRejection).toBeInstanceOf(HaltRejection);
@@ -194,7 +194,7 @@ describe("adviceHandlers", () => {
 
       const handleTask = handleRejection(chain);
       await expect(handleTask(stringError)).rejects.toBeInstanceOf(
-        HaltRejection
+        HaltRejection,
       );
 
       expect(context.haltRejection).toBeInstanceOf(HaltRejection);
@@ -240,7 +240,7 @@ describe("adviceHandlers", () => {
 
       // Then handle halt error - should set haltRejection and throw
       await expect(handleTask(haltRejection)).rejects.toBeInstanceOf(
-        HaltRejection
+        HaltRejection,
       );
       expect(context.haltRejection).toBeInstanceOf(HaltRejection);
       // Continue rejections should still be preserved
@@ -262,7 +262,7 @@ describe("adviceHandlers", () => {
       const handleTask = handleRejection(chain);
 
       await expect(handleTask(targetError)).rejects.toBeInstanceOf(
-        HaltRejection
+        HaltRejection,
       );
 
       // Existing continue rejections should be preserved
@@ -277,7 +277,7 @@ describe("adviceHandlers", () => {
       // First handle an error to set haltRejection
       const handleTask = handleRejection(chain);
       await expect(handleTask(new Error("test"))).rejects.toBeInstanceOf(
-        HaltRejection
+        HaltRejection,
       );
 
       // Now checkRejection should throw the haltRejection

--- a/packages/promise-aop/src/lib/features/chaining/__tests__/adviceTasks.test.ts
+++ b/packages/promise-aop/src/lib/features/chaining/__tests__/adviceTasks.test.ts
@@ -36,7 +36,7 @@ describe("adviceTasks", () => {
     createIdDataContext("test", 42);
 
   const createMockAdvices = (
-    overrides: Partial<AspectOrganization<TestResult, TestSharedContext>> = {}
+    overrides: Partial<AspectOrganization<TestResult, TestSharedContext>> = {},
   ): AspectOrganization<TestResult, TestSharedContext> =>
     createCommonAdvices<TestResult, TestSharedContext>(overrides);
 
@@ -49,7 +49,7 @@ describe("adviceTasks", () => {
   > => createProcessOptionsMock<TestResult, TestSharedContext>();
 
   const createMockChainContext = (
-    overrides: Partial<AdviceChainContext<TestResult, TestSharedContext>> = {}
+    overrides: Partial<AdviceChainContext<TestResult, TestSharedContext>> = {},
   ): (() => AdviceChainContext<TestResult, TestSharedContext>) => {
     const context: AdviceChainContext<TestResult, TestSharedContext> = {
       target: createMockTarget(100),
@@ -144,7 +144,7 @@ describe("adviceTasks", () => {
         const finalTarget = result(nextChain);
         const wrappedResult = await finalTarget();
         expect(wrappedResult).toBe(expectedResult);
-      }
+      },
     );
 
     it("should handle fallback resolver correctly", async () => {
@@ -155,7 +155,7 @@ describe("adviceTasks", () => {
           (_: Target<TestResult>) =>
             (_: (t: Target<TestResult>) => Target<TestResult>) =>
             async () =>
-              fallbackValue
+              fallbackValue,
         );
       const chainContext = createMockChainContext();
 
@@ -210,7 +210,7 @@ describe("adviceTasks", () => {
           id: "test",
           data: 42,
         },
-        42
+        42,
       );
       expect(result).toBe(42);
     });

--- a/packages/promise-aop/src/lib/features/chaining/__tests__/executeAdviceChain.test.ts
+++ b/packages/promise-aop/src/lib/features/chaining/__tests__/executeAdviceChain.test.ts
@@ -32,11 +32,11 @@ describe("executeAdviceChain", () => {
 
   const createMockContext = (
     id = "test",
-    data = 42
+    data = 42,
   ): (() => TestSharedContext) => createIdDataContext(id, data);
 
   const createMockAdvices = (
-    overrides: Partial<AspectOrganization<TestResult, TestSharedContext>> = {}
+    overrides: Partial<AspectOrganization<TestResult, TestSharedContext>> = {},
   ): AspectOrganization<TestResult, TestSharedContext> =>
     createCommonAdvices<TestResult, TestSharedContext>(overrides);
 
@@ -44,7 +44,7 @@ describe("executeAdviceChain", () => {
     defaultBuildOptions();
 
   const createMockProcessOptions = (
-    fallbackValue: TestResult = -999
+    fallbackValue: TestResult = -999,
   ): RequiredProcessOptions<TestResult, TestSharedContext> =>
     createProcessOptionsMock<TestResult, TestSharedContext>({
       resolveHaltRejection: jest
@@ -53,7 +53,7 @@ describe("executeAdviceChain", () => {
     });
 
   const createTestProps = (
-    overrides: Partial<__Props<TestResult, TestSharedContext>> = {}
+    overrides: Partial<__Props<TestResult, TestSharedContext>> = {},
   ): __Props<TestResult, TestSharedContext> => ({
     target: createMockTarget(100),
     context: createMockContext(),
@@ -96,7 +96,7 @@ describe("executeAdviceChain", () => {
       expect(mockAdvices.before).toHaveBeenCalledWith(expectedContext);
       expect(mockAdvices.afterReturning).toHaveBeenCalledWith(
         expectedContext,
-        100
+        100,
       ); // context and result
       expect(mockAdvices.after).toHaveBeenCalledWith(expectedContext);
     });
@@ -130,7 +130,7 @@ describe("executeAdviceChain", () => {
       expect(mockAdvices.afterThrowing).toHaveBeenCalledTimes(1);
       expect(mockAdvices.afterThrowing).toHaveBeenCalledWith(
         { id: "test", data: 42 },
-        targetError
+        targetError,
       );
       expect(mockAdvices.after).toHaveBeenCalledTimes(1);
     });
@@ -195,19 +195,19 @@ describe("executeAdviceChain", () => {
           createTestProps({
             context: () => ({ id: "parallel-1", data: 10 }),
             target: createMockTarget(1),
-          })
+          }),
         ),
         executeAdviceChain(
           createTestProps({
             context: () => ({ id: "parallel-2", data: 20 }),
             target: createMockTarget(2),
-          })
+          }),
         ),
         executeAdviceChain(
           createTestProps({
             context: () => ({ id: "parallel-3", data: 30 }),
             target: createMockTarget(3),
-          })
+          }),
         ),
       ]);
 

--- a/packages/promise-aop/src/lib/features/chaining/__tests__/rejectionHandlers.test.ts
+++ b/packages/promise-aop/src/lib/features/chaining/__tests__/rejectionHandlers.test.ts
@@ -43,7 +43,7 @@ describe("rejectionHandlers", () => {
     fallbackValue: TestResult = -999,
     overrides: Partial<
       RequiredProcessOptions<TestResult, TestSharedContext>
-    > = {}
+    > = {},
   ): RequiredProcessOptions<TestResult, TestSharedContext> =>
     createProcessOptionsMock<TestResult, TestSharedContext>({
       resolveHaltRejection: jest
@@ -53,7 +53,7 @@ describe("rejectionHandlers", () => {
     });
 
   const createMockChainContext = (
-    overrides: Partial<AdviceChainContext<TestResult, TestSharedContext>> = {}
+    overrides: Partial<AdviceChainContext<TestResult, TestSharedContext>> = {},
   ): AdviceChainContext<TestResult, TestSharedContext> => ({
     target: createMockTarget(100),
     context: createMockContext(),
@@ -110,7 +110,7 @@ describe("rejectionHandlers", () => {
       expect(mockProcessOptions.resolveHaltRejection).toHaveBeenCalledWith(
         expect.any(Function),
         expect.any(Function),
-        haltRejection
+        haltRejection,
       );
       expect(result).toBe(fallbackValue);
     });
@@ -155,7 +155,7 @@ describe("rejectionHandlers", () => {
       expect(mockProcessOptions.resolveHaltRejection).toHaveBeenCalledWith(
         expect.any(Function),
         expect.any(Function),
-        haltRejection
+        haltRejection,
       );
     });
 
@@ -183,7 +183,7 @@ describe("rejectionHandlers", () => {
       expect(mockProcessOptions.resolveHaltRejection).toHaveBeenCalledWith(
         expect.any(Function),
         expect.any(Function),
-        haltRejection
+        haltRejection,
       );
     });
   });
@@ -214,14 +214,14 @@ describe("rejectionHandlers", () => {
       await handler();
 
       expect(
-        mockProcessOptions.resolveContinuousRejection
+        mockProcessOptions.resolveContinuousRejection,
       ).toHaveBeenCalledTimes(1);
       expect(
-        mockProcessOptions.resolveContinuousRejection
+        mockProcessOptions.resolveContinuousRejection,
       ).toHaveBeenCalledWith(
         expect.any(Function),
         expect.any(Function),
-        continuousRejections
+        continuousRejections,
       );
     });
 
@@ -237,10 +237,10 @@ describe("rejectionHandlers", () => {
       await handler();
 
       expect(
-        mockProcessOptions.resolveContinuousRejection
+        mockProcessOptions.resolveContinuousRejection,
       ).toHaveBeenCalledTimes(1);
       expect(
-        mockProcessOptions.resolveContinuousRejection
+        mockProcessOptions.resolveContinuousRejection,
       ).toHaveBeenCalledWith(expect.any(Function), expect.any(Function), []);
     });
 
@@ -262,7 +262,7 @@ describe("rejectionHandlers", () => {
       await handler();
 
       expect(
-        mockProcessOptions.resolveContinuousRejection
+        mockProcessOptions.resolveContinuousRejection,
       ).toHaveBeenCalledWith(expect.any(Function), expect.any(Function), [
         continuousRejection,
       ]);
@@ -314,7 +314,7 @@ describe("rejectionHandlers", () => {
       await handler();
 
       expect(
-        mockProcessOptions.resolveContinuousRejection
+        mockProcessOptions.resolveContinuousRejection,
       ).toHaveBeenCalledWith(expect.any(Function), expect.any(Function), [
         continuousRejection,
       ]);
@@ -347,7 +347,7 @@ describe("rejectionHandlers", () => {
       await continuousHandler();
 
       expect(
-        mockProcessOptions.resolveContinuousRejection
+        mockProcessOptions.resolveContinuousRejection,
       ).toHaveBeenCalledWith(expect.any(Function), expect.any(Function), [
         continuousRejection,
       ]);
@@ -389,11 +389,11 @@ describe("rejectionHandlers", () => {
       await handler();
 
       expect(
-        mockProcessOptions.resolveContinuousRejection
+        mockProcessOptions.resolveContinuousRejection,
       ).toHaveBeenCalledWith(
         expect.any(Function),
         expect.any(Function),
-        mixedRejections
+        mixedRejections,
       );
     });
   });

--- a/packages/promise-aop/src/lib/features/chaining/adviceHandlers.ts
+++ b/packages/promise-aop/src/lib/features/chaining/adviceHandlers.ts
@@ -9,7 +9,7 @@ import { exhaustiveCheckType, validateType } from "@/lib/utils/validateType";
 import type { AdviceChainContext } from "./context";
 
 export function checkRejection<Result, SharedContext>(
-  chain: () => AdviceChainContext<Result, SharedContext>
+  chain: () => AdviceChainContext<Result, SharedContext>,
 ) {
   return async () => {
     if (chain().haltRejection) {
@@ -19,7 +19,7 @@ export function checkRejection<Result, SharedContext>(
 }
 
 export function handleRejection<Result, SharedContext>(
-  chain: () => AdviceChainContext<Result, SharedContext>
+  chain: () => AdviceChainContext<Result, SharedContext>,
 ) {
   return async (error: unknown) => {
     // if error is halt rejection, continue propagating
@@ -35,7 +35,7 @@ export function handleRejection<Result, SharedContext>(
       const afterThrow = validateType(
         ErrorAfter,
         chain().buildOptions.advice[error.info.extraInfo.advice].error.runtime
-          .afterThrow
+          .afterThrow,
       );
 
       switch (afterThrow) {

--- a/packages/promise-aop/src/lib/features/chaining/adviceTasks.ts
+++ b/packages/promise-aop/src/lib/features/chaining/adviceTasks.ts
@@ -6,7 +6,7 @@ import { checkRejection, handleRejection } from "./adviceHandlers";
 import type { AdviceChainContext } from "./context";
 
 export function beforeAdviceTask<Result, SharedContext>(
-  chain: () => AdviceChainContext<Result, SharedContext>
+  chain: () => AdviceChainContext<Result, SharedContext>,
 ) {
   return async () => {
     const beforeAdvice = async () => chain().advices.before(chain().context());
@@ -17,7 +17,7 @@ export function beforeAdviceTask<Result, SharedContext>(
 
 export function aroundAdviceTask<Result, SharedContext>(
   chain: () => AdviceChainContext<Result, SharedContext>,
-  process = processAroundAdvice
+  process = processAroundAdvice,
 ) {
   return async () => {
     const resolve = await process({
@@ -47,7 +47,7 @@ export function executeTargetTask<Result>(target: Target<Result>) {
 }
 
 export function afterReturningAdviceTask<Result, SharedContext>(
-  chain: () => AdviceChainContext<Result, SharedContext>
+  chain: () => AdviceChainContext<Result, SharedContext>,
 ) {
   return async (result: Result) => {
     const afterReturningAdvice = async () =>
@@ -62,7 +62,7 @@ export function afterReturningAdviceTask<Result, SharedContext>(
 }
 
 export function afterThrowingAdviceTask<Result, SharedContext>(
-  chain: () => AdviceChainContext<Result, SharedContext>
+  chain: () => AdviceChainContext<Result, SharedContext>,
 ) {
   return async (error: unknown) => {
     const afterThrowingAdvice = async () => {
@@ -91,7 +91,7 @@ export function afterThrowingAdviceTask<Result, SharedContext>(
 }
 
 export function afterAdviceTask<Result, SharedContext>(
-  chain: () => AdviceChainContext<Result, SharedContext>
+  chain: () => AdviceChainContext<Result, SharedContext>,
 ) {
   return async () => {
     const afterAdvice = async () => chain().advices.after(chain().context());

--- a/packages/promise-aop/src/lib/features/chaining/executeAdviceChain.ts
+++ b/packages/promise-aop/src/lib/features/chaining/executeAdviceChain.ts
@@ -23,13 +23,13 @@ import {
 } from "./rejectionHandlers";
 
 export async function executeAdviceChain<Result, SharedContext>(
-  props: __Props<Result, SharedContext>
+  props: __Props<Result, SharedContext>,
 ): Promise<__Return<Result>> {
   const AdviceChainContext = AsyncContext.create(
     (): AdviceChainContext<Result, SharedContext> => ({
       ...props,
       continueRejections: [],
-    })
+    }),
   );
 
   return AsyncContext.execute(AdviceChainContext, async (chain) => {
@@ -45,8 +45,8 @@ export async function executeAdviceChain<Result, SharedContext>(
                 .catch(afterThrowingAdviceTask(chain))
                 .finally(afterAdviceTask(chain))
                 .catch(resolveHaltRejection(chain))
-                .finally(handleContinuousRejection(chain))
-          )
+                .finally(handleContinuousRejection(chain)),
+          ),
         )
         .then(executeTargetTask)
         // recover from halt error that occurred in upper stages (before/around etc.)

--- a/packages/promise-aop/src/lib/features/chaining/rejectionHandlers.ts
+++ b/packages/promise-aop/src/lib/features/chaining/rejectionHandlers.ts
@@ -3,14 +3,14 @@ import { HaltRejection } from "@/lib/models/rejection";
 import { AdviceChainContext } from "./context";
 
 export function resolveHaltRejection<Result, SharedContext>(
-  chain: () => AdviceChainContext<Result, SharedContext>
+  chain: () => AdviceChainContext<Result, SharedContext>,
 ) {
   return async (error: unknown) => {
     if (error instanceof HaltRejection) {
       const fallback = await chain().processOptions.resolveHaltRejection(
         chain().context,
         chain().exit,
-        error
+        error,
       );
 
       return fallback();
@@ -21,13 +21,13 @@ export function resolveHaltRejection<Result, SharedContext>(
 }
 
 export function handleContinuousRejection<Result, SharedContext>(
-  chain: () => AdviceChainContext<Result, SharedContext>
+  chain: () => AdviceChainContext<Result, SharedContext>,
 ) {
   return async () => {
     await chain().processOptions.resolveContinuousRejection(
       chain().context,
       chain().exit,
-      chain().continueRejections
+      chain().continueRejections,
     );
   };
 }

--- a/packages/promise-aop/src/lib/features/processing/__tests__/processBatchAdvice.test.ts
+++ b/packages/promise-aop/src/lib/features/processing/__tests__/processBatchAdvice.test.ts
@@ -33,7 +33,7 @@ describe("processBatchAdvice", () => {
   });
 
   const createTestOptions = (
-    aggregation: AggregationUnit = "unit"
+    aggregation: AggregationUnit = "unit",
   ): RequiredBuildOptions["advice"][TestAdviceType] => ({
     execution: "parallel",
     error: {
@@ -46,7 +46,7 @@ describe("processBatchAdvice", () => {
 
   const createSuccessfulAdvice =
     (
-      delay: number = 0
+      delay: number = 0,
     ): AdviceFunctionWithContext<
       TestResult,
       TestSharedContext,
@@ -61,7 +61,7 @@ describe("processBatchAdvice", () => {
   const createFailingAdvice =
     (
       errorMessage: string,
-      delay: number = 0
+      delay: number = 0,
     ): AdviceFunctionWithContext<
       TestResult,
       TestSharedContext,
@@ -296,7 +296,7 @@ describe("processBatchAdvice", () => {
         | undefined;
 
       const contextCapturingAdvice = async (
-        context: Restricted<TestSharedContext, ["database", "logger"]>
+        context: Restricted<TestSharedContext, ["database", "logger"]>,
       ) => {
         capturedContext = context;
         // Access allowed sections
@@ -334,7 +334,7 @@ describe("processBatchAdvice", () => {
 
     it("should handle advice with no use sections (empty array)", async () => {
       const minimalAdvice = async (
-        _context: Restricted<TestSharedContext, []>
+        _context: Restricted<TestSharedContext, []>,
       ) => {
         // Should have no access to any context properties
       };
@@ -363,7 +363,10 @@ describe("processBatchAdvice", () => {
 
     it("should handle advice without explicit use property", async () => {
       const defaultAdvice = async (
-        _context: Restricted<TestSharedContext, SectionsUsed<TestSharedContext>>
+        _context: Restricted<
+          TestSharedContext,
+          SectionsUsed<TestSharedContext>
+        >,
       ) => {
         // Default behavior when use is not specified
       };

--- a/packages/promise-aop/src/lib/features/processing/processBatchAdvice.ts
+++ b/packages/promise-aop/src/lib/features/processing/processBatchAdvice.ts
@@ -13,7 +13,7 @@ import { exhaustiveCheckType, validateType } from "@/lib/utils/validateType";
 export async function processBatchAdvice<
   Result,
   SharedContext,
-  AdviceType extends Advice
+  AdviceType extends Advice,
 >({
   context,
   options,
@@ -33,9 +33,9 @@ export async function processBatchAdvice<
       group.map((task) => {
         return restrictedContext.use(
           async (ctx) => task.advice(ctx, ...args),
-          task.use ?? ([] as SectionsUsed<SharedContext>)
+          task.use ?? ([] as SectionsUsed<SharedContext>),
         );
-      })
+      }),
     );
 
     // errors(rejections) from unit advice

--- a/packages/promise-aop/src/lib/models/advice.ts
+++ b/packages/promise-aop/src/lib/models/advice.ts
@@ -14,13 +14,13 @@ export type Advice = (typeof Advice)[number];
 
 export type AdviceFunction<
   Result,
-  AdviceType extends Advice
+  AdviceType extends Advice,
 > = AdviceFunctionMappings<Result>[AdviceType];
 
 export type AdviceFunctionWithContext<
   Result,
   SharedContext,
-  AdviceType extends Advice
+  AdviceType extends Advice,
 > = (
   context: SharedContext,
   ...args: Parameters<AdviceFunction<Result, AdviceType>>
@@ -30,7 +30,7 @@ export type AdviceMetadata<
   Result,
   SharedContext,
   AdviceType extends Advice,
-  Sections extends SectionsUsed<SharedContext> = SectionsUsed<SharedContext>
+  Sections extends SectionsUsed<SharedContext> = SectionsUsed<SharedContext>,
 > = {
   readonly use?: Sections;
   readonly dependsOn?: readonly string[];
@@ -44,7 +44,7 @@ export type AdviceMetadata<
 export type AdviceExecution<
   Result,
   SharedContext,
-  AdviceType extends Advice
+  AdviceType extends Advice,
 > = AdviceMetadata<Result, SharedContext, AdviceType>[][];
 
 // advice function must be async & void function

--- a/packages/promise-aop/src/lib/models/process.ts
+++ b/packages/promise-aop/src/lib/models/process.ts
@@ -8,5 +8,5 @@ import type { Target } from "./target";
 export type Process<Result, SharedContext> = (
   context: ContextAccessor<SharedContext>,
   exit: ExecutionOuterContext,
-  target: Target<Result>
+  target: Target<Result>,
 ) => Promise<Result>;

--- a/packages/promise-aop/src/lib/models/processOptions.ts
+++ b/packages/promise-aop/src/lib/models/processOptions.ts
@@ -14,12 +14,12 @@ export type RequiredProcessOptions<Result, SharedContext> = {
   readonly resolveHaltRejection: (
     context: ContextAccessor<SharedContext>,
     exit: ExecutionOuterContext,
-    error: HaltRejection
+    error: HaltRejection,
   ) => Promise<Target<Result>>;
   readonly resolveContinuousRejection: (
     context: ContextAccessor<SharedContext>,
     exit: ExecutionOuterContext,
-    error: ContinuousRejection[]
+    error: ContinuousRejection[],
   ) => Promise<void>;
 };
 
@@ -32,7 +32,7 @@ export function normalizeProcessOptions<Result, SharedContext>(
   defaultOptions: RequiredProcessOptions<
     Result,
     SharedContext
-  > = defaultProcessOptions()
+  > = defaultProcessOptions(),
 ): RequiredProcessOptions<Result, SharedContext> {
   return normalizeOptions(defaultOptions, options);
 }

--- a/packages/promise-aop/src/lib/models/target.ts
+++ b/packages/promise-aop/src/lib/models/target.ts
@@ -1,5 +1,5 @@
 export type Target<Result> = () => Promise<Result>;
 export type TargetWrapper<Result> = (target: Target<Result>) => Target<Result>;
 export type AroundAdviceResolver<Result> = (
-  nextChain: TargetWrapper<Result>
+  nextChain: TargetWrapper<Result>,
 ) => Target<Result>;

--- a/packages/promise-aop/src/lib/utils/AsyncContext.ts
+++ b/packages/promise-aop/src/lib/utils/AsyncContext.ts
@@ -3,7 +3,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 export class AsyncContext<SharedContext> {
   private constructor(
     private readonly contextGenerator?: ContextGenerator<SharedContext>,
-    private readonly contextStore = new AsyncLocalStorage<SharedContext>()
+    private readonly contextStore = new AsyncLocalStorage<SharedContext>(),
   ) {}
 
   public context: ContextAccessor<SharedContext> = () => {
@@ -23,15 +23,15 @@ export class AsyncContext<SharedContext> {
     { contextGenerator, contextStore, context, exit }: AsyncContext<P>,
     operation: (
       context: AsyncContext<P>["context"],
-      exit: AsyncContext<P>["exit"]
-    ) => Promise<Q>
+      exit: AsyncContext<P>["exit"],
+    ) => Promise<Q>,
   ): Promise<Q> {
     if (!contextGenerator) {
       throw new Error(MSG_ERR_ASYNC_CONTEXT_GENERATOR_NOT_PROVIDED);
     }
 
     return contextStore.run(contextGenerator(), async () =>
-      operation(context, exit)
+      operation(context, exit),
     );
   }
 
@@ -40,11 +40,11 @@ export class AsyncContext<SharedContext> {
     contextGenerator: () => P,
     operation: (
       context: AsyncContext<P>["context"],
-      exit: AsyncContext<P>["exit"]
-    ) => Promise<Q>
+      exit: AsyncContext<P>["exit"],
+    ) => Promise<Q>,
   ): Promise<Q> {
     return contextStore.run(contextGenerator(), async () =>
-      operation(context, exit)
+      operation(context, exit),
     );
   }
 
@@ -56,7 +56,7 @@ export class AsyncContext<SharedContext> {
 export type ContextGenerator<SharedContext> = () => SharedContext;
 export type ContextAccessor<SharedContext> = () => SharedContext;
 export type ExecutionOuterContext = <SharedContext>(
-  callback: () => SharedContext
+  callback: () => SharedContext,
 ) => SharedContext;
 
 /**

--- a/packages/promise-aop/src/runProcess.ts
+++ b/packages/promise-aop/src/runProcess.ts
@@ -11,7 +11,7 @@ export async function runProcess<Result, SharedContext>({
     typeof context === "function" ? AsyncContext.create(context) : context;
 
   return AsyncContext.execute(asyncContext, async (ctx, exit) =>
-    process(ctx, exit, target)
+    process(ctx, exit, target),
   );
 }
 


### PR DESCRIPTION
## 요약

- Prettier 설정이 IDE와 제대로 연동되지 않은 문제를 해결합니다.

## 작업 내용

- IDE의 Prettier Server가 prettier.config.mjs를 인식하지 못하여, 기본(폴백) 설정으로 formatting되고 있었습니다.
- prettier.config.mjs -> .prettierrc로 수정하여 제대로 인식되도록 했습니다.
- IDE 설정에서, Prettier가 무조건 config을 요구하도록 수정하였습니다.

## 범위

- @h1y/promise-aop (v3.0.0)
- @h1y/next-loader (v1.0.1)