### PR TITLE
fix(promise aop): resolve context loss

### DIFF
--- a/.changeset/brave-clouds-nail.md
+++ b/.changeset/brave-clouds-nail.md
@@ -1,0 +1,5 @@
+---
+"@h1y/promise-aop": patch
+---
+
+fixed async advice execution by adding explicit await to ensure afterThrowing completes before error propagation.

--- a/packages/promise-aop/src/lib/features/chaining/adviceTasks.ts
+++ b/packages/promise-aop/src/lib/features/chaining/adviceTasks.ts
@@ -8,9 +8,11 @@ import type { AdviceChainContext } from "./context";
 export function beforeAdviceTask<Result, SharedContext>(
   chain: () => AdviceChainContext<Result, SharedContext>,
 ) {
-  return async () => {
-    const beforeAdvice = async () => chain().advices.before(chain().context());
+  const beforeAdvice = async () => {
+    await chain().advices.before(chain().context());
+  };
 
+  return async () => {
     return Promise.resolve().then(beforeAdvice).catch(handleRejection(chain));
   };
 }
@@ -50,8 +52,9 @@ export function afterReturningAdviceTask<Result, SharedContext>(
   chain: () => AdviceChainContext<Result, SharedContext>,
 ) {
   return async (result: Result) => {
-    const afterReturningAdvice = async () =>
-      chain().advices.afterReturning(chain().context(), result);
+    const afterReturningAdvice = async () => {
+      await chain().advices.afterReturning(chain().context(), result);
+    };
 
     return Promise.resolve()
       .then(checkRejection(chain))
@@ -66,7 +69,7 @@ export function afterThrowingAdviceTask<Result, SharedContext>(
 ) {
   return async (error: unknown) => {
     const afterThrowingAdvice = async () => {
-      chain().advices.afterThrowing(chain().context(), error);
+      await chain().advices.afterThrowing(chain().context(), error);
     };
 
     // explicitly propagate the error from the target.
@@ -93,9 +96,11 @@ export function afterThrowingAdviceTask<Result, SharedContext>(
 export function afterAdviceTask<Result, SharedContext>(
   chain: () => AdviceChainContext<Result, SharedContext>,
 ) {
-  return async () => {
-    const afterAdvice = async () => chain().advices.after(chain().context());
+  const afterAdvice = async () => {
+    await chain().advices.after(chain().context());
+  };
 
+  return async () => {
     return Promise.resolve().then(afterAdvice).catch(handleRejection(chain));
   };
 }


### PR DESCRIPTION
## 요약

- afterThrowing advice를 수행할 때, Promise Chain이 유지되지 않고 소실되는 버그를 해결하였습니다.

## 작업 내용

- AdviceChain 로직에서 afterThrowing advice를 호출할 때, await가 누락되어 Chain이 유지되지 않는 문제를 수정하였습니다.
- afterThrowing 관련 테스트를 보강하였습니다.

## 범위

- @h1y/promise-aop (v3.0.0 -> v3.0.1)
