### PR TITLE
ci: turborepo 의존성을 수정하여 빌드가 제대로 수행되지 않는 문제 해결

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -11,13 +11,13 @@
       "dependsOn": ["^build"]
     },
     "lint": {
-      "dependsOn": ["^lint"]
+      "dependsOn": ["^build", "^lint"]
     },
     "format": {
       "dependsOn": ["^format"]
     },
     "check-types": {
-      "dependsOn": ["^check-types"]
+      "dependsOn": ["^build", "^check-types"]
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
## 요약

- 모노레포 내 프로젝트 빌드 과정에서, 명령어 간 필수 의존성을 명시하지 않아 생기는 에러를 해결합니다.

## 작업 내용

- turborepo config에서, lint와 check-types는 상위 의존성 (프로젝트)의 빌드가 먼저 수행되어야 합니다. 따라서, 선행 빌드 여부를 추가했습니다.
