### PR TITLE
feat(loader-core): 상위 라이브러리에 필요한 타입을 내보내기

### DIFF
--- a/.changeset/salty-spoons-tie.md
+++ b/.changeset/salty-spoons-tie.md
@@ -1,0 +1,5 @@
+---
+"@h1y/loader-core": minor
+---
+
+export some middleware types

--- a/packages/loader-core/src/index.ts
+++ b/packages/loader-core/src/index.ts
@@ -8,6 +8,18 @@ export { TimeoutSignal } from "@/lib/signals/TimeoutSignal";
 export { loader } from "./loader";
 export { middleware } from "./middleware";
 
+// types
+export type { BackoffContextInput } from "@/lib/models/backoff";
+export type { LoaderCoreInput } from "@/lib/models/context";
+export type {
+  LoaderMiddleware,
+  MiddlewareContext,
+  MiddlewareOptions,
+} from "@/lib/models/middleware";
+export type { LoaderCoreOptions } from "@/lib/models/options";
+export type { RetryContextInput } from "@/lib/models/retry";
+export type { TimeoutContextInput } from "@/lib/models/timeout";
+
 // backoff strategies
 export {
   createBackoff,

--- a/packages/loader-core/src/lib/models/middleware.ts
+++ b/packages/loader-core/src/lib/models/middleware.ts
@@ -10,7 +10,7 @@ export type LoaderMiddleware<Result, Context, MiddlewareName extends string> = {
 export type MiddlewareOptions<
   Middlewares extends readonly LoaderMiddleware<any, unknown, string>[],
 > = {
-  [K in Middlewares[number] as K["name"]]: () => ReturnType<
+  readonly [K in Middlewares[number] as K["name"]]: () => ReturnType<
     K["contextGenerator"]
   >;
 };
@@ -18,7 +18,7 @@ export type MiddlewareOptions<
 export type MiddlewareContext<
   Middlewares extends readonly LoaderMiddleware<any, unknown, string>[],
 > = {
-  [K in Middlewares[number] as K["name"]]: K extends LoaderMiddleware<
+  readonly [K in Middlewares[number] as K["name"]]: K extends LoaderMiddleware<
     any,
     infer Context,
     any


### PR DESCRIPTION
## 요약

- next-loader를 만들면서 필요한 내부 타입을 내보냈습니다.

## 작업 내용

- 미들웨어를 구성하는 데 필요한 타입을 내보냈습니다.
- 로더의 필수 옵션을 구성하는 데 필요한 타입을 내보냈습니다.

## 범위

- @h1y/loader-core (v1.0.1 -> v1.1.0)
